### PR TITLE
fixed file name truncation

### DIFF
--- a/host/tornado/src/jbox_container.py
+++ b/host/tornado/src/jbox_container.py
@@ -244,9 +244,6 @@ class JBoxContainer:
                 continue
             if info.name.startswith('juser/resty'):
                 continue
-            info.name = info.name[6:]
-            if len(info.name) == 0:
-                continue
             dest_tar.addfile(info, src_tar.extractfile(info))
         src_tar.close()
         dest_tar.close()


### PR DESCRIPTION
filtering of backups was removing one path element which would result in truncated file names on restore.
