### PR TITLE
changes for load balancing and auto scaling

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -4,7 +4,7 @@ Following packages are installed by default. Additional packages can be installe
 
 However, user installed packages may not be retained across sessions. Also since the JuliaBox user is not a priviledged user, packages requiring additional system packages may not install correctly. There will be an alternate mechanism for installing additional packages in the future.
 
-- 15 required packages:
+- 17 required packages:
     - Clp
     - DataFrames
     - DataStructures
@@ -12,6 +12,8 @@ However, user installed packages may not be retained across sessions. Also since
     - Gadfly
     - HDF5
     - IJulia
+    - Interact
+    - Ipopt
     - Iterators
     - JuMP
     - MCMC
@@ -20,7 +22,7 @@ However, user installed packages may not be retained across sessions. Also since
     - Optim
     - PyPlot
     - SymPy
-- 37 additional packages:
+- 38 additional packages:
     - ArrayViews
     - BinDeps
     - Calculus
@@ -50,6 +52,7 @@ However, user installed packages may not be retained across sessions. Also since
     - PDMats
     - PyCall
     - REPLCompletions
+    - Reactive
     - Reexport
     - ReverseDiffSource
     - ReverseDiffSparse

--- a/docker/IJulia/Dockerfile
+++ b/docker/IJulia/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get install -y \
         python-sympy \
 		glpk-utils \
 		libnlopt0 \
+		gfortran \
+		pkg-config \
 		pandoc \
         && apt-get clean
 
@@ -20,7 +22,7 @@ WORKDIR /home/juser
 
 RUN ipython profile create julia
 RUN julia -e 'Pkg.init(); Pkg.add("IJulia"); Pkg.add("PyPlot"); Pkg.add("Gadfly"); Pkg.add("DataFrames"); Pkg.add("DataStructures"); Pkg.add("HDF5"); Pkg.add("Iterators"); Pkg.add("MCMC"); Pkg.add("NumericExtensions"); Pkg.add("Optim"); Pkg.add("JuMP"); Pkg.add("SymPy");'
-RUN julia -e 'Pkg.add("GLPKMathProgInterface"); Pkg.add("Clp"); Pkg.add("NLopt"); Pkg.add("Interact");'
+RUN julia -e 'Pkg.add("GLPKMathProgInterface"); Pkg.add("Clp"); Pkg.add("NLopt"); Pkg.add("Ipopt"); Pkg.add("Interact");'
 
 RUN echo "c.NotebookApp.open_browser = False" >> /home/juser/.ipython/profile_julia/ipython_notebook_config.py \
 	&& echo "c.NotebookApp.ip = \"*\"" >> /home/juser/.ipython/profile_julia/ipython_notebook_config.py

--- a/host/nginx/www/assets/js/juliabox.js
+++ b/host/nginx/www/assets/js/juliabox.js
@@ -258,7 +258,9 @@ var JuliaBox = (function(){
     	
     	logout_at_browser: function () {
 			for (var it in $.cookie()) {
-				$.removeCookie(it);
+				if(it in ["sessname", "hostshell", "hostupload", "hostipnb", "sign", "juliabox"]) {
+					$.removeCookie(it);
+				}
 			}
 			top.location.href = '/';
 			top.location.reload(true);    		

--- a/host/tornado/conf/tornado.conf.tpl
+++ b/host/tornado/conf/tornado.conf.tpl
@@ -1,19 +1,19 @@
 {
     "port" : 8888,
     "gauth" : $$GAUTH,
-    "dhostlocal" : True,
     
+    # Self teminate if required to scale down
+    "scale_down" : False,
     # Number of active containers to allow per instance
     "numlocalmax" : $$NUM_LOCALMAX,
-    
     # Maximum number of hops through the load balancer till the installation is declared overloaded
     "numhopmax": 10,
+    
+    # Installation specific session key. Used for encryption and signing. 
     "sesskey" : "$$SESSKEY",
     
     # Users that have access to the admin tab
     "admin_users" : ["$$ADMIN_USER"],
-    
-    "dhosts" : [],
     
     # Sessions which will not be timed out and auto-cleaned up
     "protected_sessions" : [],

--- a/host/tornado/src/jbox_util.py
+++ b/host/tornado/src/jbox_util.py
@@ -1,5 +1,5 @@
-import os, sys, time, errno, datetime
-import boto.dynamodb, boto.utils, boto.ec2.cloudwatch
+import os, sys, time, errno, datetime, psutil, isodate, pytz
+import boto.dynamodb, boto.utils, boto.ec2, boto.ec2.cloudwatch
 from boto.s3.key import Key
 
 
@@ -48,6 +48,7 @@ def unquote(s):
 class CloudHelper:
     REGION = 'us-east-1'
     INSTALL_ID = 'JuliaBox'
+    EC2_CONN = None
     DYNAMODB_CONN = None
     S3_CONN = None
     S3_BUCKETS = {}
@@ -55,6 +56,7 @@ class CloudHelper:
     ENABLED = {}
     INSTANCE_ID = None
     SELF_STATS = {}
+    # STATS_CACHE = {} # TODO: cache stats
     
     @staticmethod
     def instance_id():
@@ -64,6 +66,31 @@ class CloudHelper:
             else:
                 CloudHelper.INSTANCE_ID = boto.utils.get_instance_metadata()['instance-id']
         return CloudHelper.INSTANCE_ID
+
+    @staticmethod
+    def instance_attrs(instance_id=None):
+        if None == instance_id:
+            instance_id = CloudHelper.instance_id()
+        if CloudHelper.ENABLED['cloudwatch']:
+            attrs = CloudHelper.connect_ec2().get_only_instances([instance_id])
+            if len(attrs) > 0:
+                return attrs[0]
+        return None
+    
+    @staticmethod
+    def uptime_minutes(instance_id=None):
+        if CloudHelper.ENABLED['cloudwatch']:
+            attrs = CloudHelper.instance_attrs(instance_id)
+            lt = isodate.parse_datetime(attrs.launch_time)
+            nt = datetime.datetime.now(pytz.utc)
+            uptime = nt - lt
+        elif instance_id != None:
+            uptime = datetime.datetime.now() - datetime.datetime.fromtimestamp(psutil.BOOT_TIME)
+        else:
+            log_info("cloudwatch disabled. can not get uptime")
+            return 0
+        minutes = (uptime.seconds + uptime.microseconds / 1000000.0) / 60.0
+        return minutes
     
     @staticmethod
     def configure(has_s3=True, has_dynamodb=True, has_cloudwatch=True, region='us-east-1', install_id='JuliaBox'):
@@ -72,6 +99,12 @@ class CloudHelper:
         CloudHelper.ENABLED['cloudwatch'] = has_cloudwatch
         CloudHelper.INSTALL_ID = install_id
         CloudHelper.REGION = region
+    
+    @staticmethod
+    def connect_ec2():
+        if (None == CloudHelper.EC2_CONN) and CloudHelper.ENABLED['cloudwatch']:
+            CloudHelper.EC2_CONN = boto.ec2.connect_to_region(CloudHelper.REGION)
+        return CloudHelper.EC2_CONN
     
     @staticmethod
     def connect_dynamodb():
@@ -126,20 +159,108 @@ class CloudHelper:
             return
         
         dims = {'InstanceID': CloudHelper.instance_id()}
-        log_info("CloudWatch " + CloudHelper.INSTALL_ID + ": " + stat_name + " = " + str(stat_value) + " " + stat_unit)
+        log_info("CloudWatch " + CloudHelper.INSTALL_ID + "." + CloudHelper.instance_id() + "." + stat_name + "=" + str(stat_value) + "(" + stat_unit + ")")
         CloudHelper.connect_cloudwatch().put_metric_data(namespace=CloudHelper.INSTALL_ID, name=stat_name, unit=stat_unit, value=stat_value, dimensions=dims)
     
     @staticmethod
-    def get_instance_stats(instance, stat_name, namespace=None):
+    def instance_accept_session_priority(instance_id, load):
+#         uptime = CloudHelper.uptime_minutes(instance_id)
+#         uptime_last_hour = uptime_mins % 60
+        # TODO:
+        # - ami changeover
+        # - hourly window
+        # - load
+        return str(int(load)) + '_' + instance_id
+    
+    @staticmethod
+    def terminate_instance(instance=None):
         if not CloudHelper.ENABLED['cloudwatch']:
-            if (instance == CloudHelper.instance_id()) and (stat_name in CloudHelper.SELF_STATS):
-                return CloudHelper.SELF_STATS[stat_name]
-            else:
-                return None
+            return
+        
+        if None == instance:
+            instance = CloudHelper.instance_id()
+        
+        log_info("Terminating instance: " + instance)
+        CloudHelper.connect_ec2().terminate_instances(instance_ids=[instance])
+        
+    
+    @staticmethod
+    def should_terminate():
+        if not CloudHelper.ENABLED['cloudwatch']:
+            return False
+        
+        uptime = CloudHelper.uptime_minutes()
+        
+        # if uptime less than hour and half return false
+        if uptime < 90:
+            log_info("not terminating as uptime (" + repr(uptime) + ") < 90")
+            return False
+
+        if not CloudHelper.ENABLED['cloudwatch']:
+            return False
+        
+        cluster_load = CloudHelper.get_cluster_stats('Load')
+        
+        # keep at least 1 machine running
+        if len(cluster_load) == 1:
+            log_info("not terminating as this is the only machine")
+            return False
+        
+        # sort by load and instance_id
+        sorted_nodes = sorted(cluster_load.iteritems(), key=lambda x: CloudHelper.instance_accept_session_priority(x[0], x[1]))
+        # if this is not the node with least load, keep running
+        if sorted_nodes[-1][0] != CloudHelper.instance_id():
+            log_info("not terminating as this is not the last node in sorted list")
+            return False
+        
+        return True
+    
+    
+    @staticmethod
+    def should_accept_session():
+        self_load = CloudHelper.get_instance_stats(CloudHelper.instance_id(), 'Load')
+        log_info("Load self: " + repr(self_load))
+        if self_load >= 100:
+            return False
+        
+        if not CloudHelper.ENABLED['cloudwatch']:
+            return True
+        
+        cluster_load = CloudHelper.get_cluster_stats('Load')
+        avg_load = CloudHelper.get_cluster_average_stats('Load', results=cluster_load)
+        log_info("Load cluster: " + repr(cluster_load) + " avg: " + repr(avg_load))
+        
+        # if not least loaded, accept
+        if self_load >= avg_load:
+            log_info("Accepting because this is not the least loaded (self load >= avg)")
+            return True
+        
+        # exclude machines with load >= avg load
+        filtered_nodes = {k: v for k,v in cluster_load.iteritems() if v >= avg_load }
+        # if this is the only instance with load less than average, accept
+        if len(filtered_nodes) == 1:
+            log_info("Accepting because this is the only instance with load less than average")
+            return True
+        # sort by load and instance_id
+        sorted_nodes = sorted(filtered_nodes.iteritems(), key=lambda x: CloudHelper.instance_accept_session_priority(x[0], x[1]))
+        # if this is not the node with least load, accept
+        if sorted_nodes[0][1] != CloudHelper.instance_id():
+            log_info("Accepting because this is not the node with least load")
+            return True
+        return False
+        
+    
+    @staticmethod
+    def get_instance_stats(instance, stat_name, namespace=None):
+        if (instance == CloudHelper.instance_id()) and (stat_name in CloudHelper.SELF_STATS):
+            log_info("Using cached self_stats. " + stat_name + "=" + repr(CloudHelper.SELF_STATS[stat_name]))
+            return CloudHelper.SELF_STATS[stat_name]
+        elif not CloudHelper.ENABLED['cloudwatch']:
+            return None        
         
         if namespace == None:
             namespace = CloudHelper.INSTALL_ID
-        end = datetime.datetime.utcnow()
+        end = datetime.datetime.utcnow()        
         start = end - datetime.timedelta(minutes=30)
         res = None
         results = CloudHelper.connect_cloudwatch().get_metric_statistics(60, start, end, stat_name, namespace, 'Average', {'InstanceID':[instance]})
@@ -203,7 +324,9 @@ class CloudHelper:
         stats = {}
         if 'InstanceID' in dims:
             for instance in dims['InstanceID']:
-                stats[instance] = CloudHelper.get_instance_stats(instance, stat_name, namespace)
+                instance_load = CloudHelper.get_instance_stats(instance, stat_name, namespace)
+                if instance_load != None:
+                    stats[instance] = instance_load
         
         return stats
     

--- a/host/tornado/www/index.tpl
+++ b/host/tornado/www/index.tpl
@@ -47,6 +47,9 @@
         	}
         	return true;
         }
+        {% if len(err) > 0 %}
+        	alert("{{err}}");
+        {% end %}
     </script>
   </head>
 


### PR DESCRIPTION
- Special cookie for load balancer to track. This takes care of the situation where user logs out and wants to log back in immediately and use the last container. Should also work for deployment across zones.
- On request of a new session, JuliaBox will redirect request through the load balancer if it can't handle any more load. If an older user sesion was present on this instance, it will be backed up to s3 before redirecting.
- The redirect scheme will also be used to actively try and have fewer instances loaded to peak capacity, rather than spread out thinly.
- Can shut down instance for scaling down. AWS auto scaling down may not work nicely with stateful instances. This needs some more work for limiting rate of scaling down, and handling the border case where the last two instances shut down simultaneously. Optional for now.

Also:
- added Ipopt package
