### PR TITLE
implemented disk limits

### DIFF
--- a/docker/IJulia/Dockerfile
+++ b/docker/IJulia/Dockerfile
@@ -1,48 +1,32 @@
 # Docker file for JuliaBox
-# Version:10
+# Version:11
 
-FROM tanmaykm/juliaboxjulia:julia_v0.3_3
+FROM tanmaykm/juliaboxjulia:julia_v0.3_4
 
 MAINTAINER Tanmay Mohapatra
 
 # Install additional packages required for Julia packages
 RUN apt-get install -y \
-        hdf5-tools \
-        python-sympy \
+		hdf5-tools \
+		python-sympy \
 		glpk-utils \
 		libnlopt0 \
 		gfortran \
-		pkg-config \
-		pandoc \
-        && apt-get clean
+		&& apt-get clean
 
-RUN mkdir -p /.julia \
-	&& chmod 777 /.julia
+
+# add juser
+RUN groupadd juser \
+    && useradd -m -d /home/juser -s /bin/bash -g juser -G staff juser \
+    && echo "export HOME=/home/juser" >> /home/juser/.bashrc
 
 USER juser
 ENV HOME /home/juser
 WORKDIR /home/juser
-
-RUN echo "export JULIA_PKGDIR=/.julia" >> /home/juser/.bashrc
-RUN ipython profile create julia
-RUN export JULIA_PKGDIR=/.julia && julia -e 'Pkg.init(); Pkg.add("IJulia"); Pkg.add("PyPlot"); Pkg.add("Gadfly"); Pkg.add("DataFrames"); Pkg.add("DataStructures"); Pkg.add("HDF5"); Pkg.add("Iterators"); Pkg.add("MCMC"); Pkg.add("NumericExtensions"); Pkg.add("SymPy"); Pkg.add("Interact");'
-RUN export JULIA_PKGDIR=/.julia && julia -e 'Pkg.add("Optim"); Pkg.add("JuMP"); Pkg.add("GLPKMathProgInterface"); Pkg.add("Clp");'
-RUN export JULIA_PKGDIR=/.julia && julia -e 'Pkg.add("NLopt"); Pkg.add("Ipopt");'
-
-RUN echo "c.NotebookApp.open_browser = False" >> /home/juser/.ipython/profile_julia/ipython_notebook_config.py \
-	&& echo "c.NotebookApp.ip = \"*\"" >> /home/juser/.ipython/profile_julia/ipython_notebook_config.py
-COPY custom.css /home/juser/.ipython/profile_julia/static/custom/custom.css
-
-RUN mkdir -p /home/juser/.juliabox /home/juser/.juliabox/tornado
-
-ADD tornado /home/juser/.juliabox/tornado/
-ADD juliabox.sh /home/juser/.juliabox/
-ADD supervisord.conf /home/juser/.juliabox/
 
 # 4200: http port for console
 # 8000: http port for tornado
 # 8998: ipython port for julia
 EXPOSE  4200 8000 8998
 
-VOLUME ["/juliabox"]
 ENTRYPOINT /usr/bin/supervisord -n -c /home/juser/.juliabox/supervisord.conf -l /home/juser/.juliabox/supervisord.log -j /home/juser/.juliabox/supervisord.pid -q /home/juser/.juliabox

--- a/docker/IJulia/supervisord.conf
+++ b/docker/IJulia/supervisord.conf
@@ -3,16 +3,6 @@ nodaemon=true
 logfile_maxbytes = 1MB
 logfile_backups = 2
 
-[program:juliabox]
-command=/home/juser/.juliabox/juliabox.sh
-stdout_logfile = /home/juser/.juliabox/juliabox.log
-stdout_logfile_backups = 2
-stdout_logfile_maxbytes = 1MB
-stderr_logfile = /home/juser/.juliabox/juliabox_err.log
-stderr_logfile_backups = 2
-stderr_logfile_maxbytes = 1MB
-environment=JULIA_PKGDIR=/.julia
-
 [program:shellinabox]
 command=shellinaboxd -t -s /:juser:juser:/home/juser:/bin/bash
 stdout_logfile = /home/juser/.juliabox/shellinabox.log
@@ -21,7 +11,6 @@ stdout_logfile_maxbytes = 1MB
 stderr_logfile = /home/juser/.juliabox/shellinabox_err.log
 stderr_logfile_backups = 2
 stderr_logfile_maxbytes = 1MB
-environment=JULIA_PKGDIR=/.julia
 
 [program:ijulia]
 command=ipython notebook --profile julia
@@ -31,7 +20,6 @@ stdout_logfile_maxbytes = 1MB
 stderr_logfile = /home/juser/.juliabox/ijulia_err.log
 stderr_logfile_backups = 2
 stderr_logfile_maxbytes = 1MB
-environment=JULIA_PKGDIR=/.julia
 
 [program:tornado]
 command=/home/juser/.juliabox/tornado/src/fmanage.py
@@ -42,4 +30,3 @@ stdout_logfile_maxbytes = 1MB
 stderr_logfile = /home/juser/.juliabox/tornado/tornado_err.log
 stderr_logfile_backups = 2
 stderr_logfile_maxbytes = 1MB
-environment=JULIA_PKGDIR=/.julia

--- a/docker/mk_user_home.sh
+++ b/docker/mk_user_home.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+JUSER_HOME=/tmp/juser
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+\rm -rf ${JUSER_HOME}
+mkdir -p ${JUSER_HOME}
+cp ${DIR}/setup_julia.sh ${JUSER_HOME}
+sudo docker run -i -v ${JUSER_HOME}:/home/juser --entrypoint="/home/juser/setup_julia.sh" juliabox/juliabox:latest
+rm ${JUSER_HOME}/setup_julia.sh
+
+echo "c.NotebookApp.open_browser = False" >> ${JUSER_HOME}/.ipython/profile_julia/ipython_notebook_config.py
+echo "c.NotebookApp.ip = \"*\"" >> ${JUSER_HOME}/.ipython/profile_julia/ipython_notebook_config.py
+cp docker/IJulia/custom.css ${JUSER_HOME}/.ipython/profile_julia/static/custom/custom.css
+
+mkdir -p ${JUSER_HOME}/.juliabox juser/.juliabox/tornado
+
+cp -R docker/IJulia/tornado ${JUSER_HOME}/.juliabox/tornado/
+cp docker/IJulia/supervisord.conf ${JUSER_HOME}/.juliabox/
+
+tar -czvf ~/user_home.tar.gz -C ${JUSER_HOME} .
+\rm -rf ${JUSER_HOME}

--- a/docker/setup_julia.sh
+++ b/docker/setup_julia.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ipython profile create julia
+
+julia -e 'Pkg.init(); Pkg.add("IJulia"); Pkg.add("PyPlot"); Pkg.add("Gadfly"); Pkg.add("DataFrames"); Pkg.add("DataStructures"); Pkg.add("HDF5"); Pkg.add("Iterators"); Pkg.add("MCMC"); Pkg.add("NumericExtensions"); Pkg.add("SymPy"); Pkg.add("Interact");'
+
+julia -e 'Pkg.add("Optim"); Pkg.add("JuMP"); Pkg.add("GLPKMathProgInterface"); Pkg.add("Clp");'
+
+julia -e 'Pkg.add("NLopt"); Pkg.add("Ipopt");'

--- a/host/tornado/conf/tornado.conf.tpl
+++ b/host/tornado/conf/tornado.conf.tpl
@@ -7,6 +7,8 @@
     "scale_down" : False,
     # Number of active containers to allow per instance
     "numlocalmax" : $$NUM_LOCALMAX,
+    # Number of disks available to be mounted to images
+    "numdisksmax" : $$NUM_DISKSMAX,
     # Maximum number of hops through the load balancer till the installation is declared overloaded
     "numhopmax": 10,
     
@@ -26,15 +28,15 @@
     "mem_limit" : 1000000000,
     # Max 1024 cpu slices. default maximum allowed is 1/8th of total cpu slices. multiplier can be applied from user profile.
     "cpu_limit" : 128,
-    # Max size of user files allowed. Default maximum allowed is 50MB. Disk images of stopped containers will be backed up every 10 minutes
-    "disk_limit" : 50000000,
+    # Max size of user home. Default 500MB. User home is backed up within 10 minutes of the container stopping.
+    "disk_limit" : 500000000,
     
     # Seconds to wait before clearing an inactive session, for example, when the user closes the browser window (protected_sessions are not affected)
     "inactivity_timeout" : 300,
     # Upper time limit for a user session before it is auto-deleted. 0 means never expire (protected_sessions are not affected)
     "expire" : $$EXPIRE,
     # Seconds before a stopped container is backed up and deleted.
-    "delete_stopped_timeout" : 600,
+    "delete_stopped_timeout" : 300,
     # Number of parallel threads to run for backups
     "backup_threads" : 2,
     
@@ -66,6 +68,8 @@
     },
     "env_type" : "prod",
     "backup_location" : "~/juliabox_backup",
+    "mnt_location" : "/mnt/jbox/mnt",
+    "user_home_image" : "~/user_home.tar.gz",
     "dummy" : "dummy"
 }
 

--- a/host/tornado/src/bkup.py
+++ b/host/tornado/src/bkup.py
@@ -8,18 +8,22 @@ if __name__ == "__main__":
     dckr = docker.Client()
     cfg = read_config()
     backup_location = os.path.expanduser(cfg['backup_location'])
+    user_home_img = os.path.expanduser(cfg['user_home_image'])
+    mnt_location = os.path.expanduser(cfg['mnt_location'])
     cloud_cfg = cfg['cloud_host']
     backup_bucket = cloud_cfg['backup_bucket']
     make_sure_path_exists(backup_location)
     
     CloudHelper.configure(has_s3=cloud_cfg['s3'], has_dynamodb=cloud_cfg['dynamodb'], has_cloudwatch=cloud_cfg['cloudwatch'], region=cloud_cfg['region'], install_id=cloud_cfg['install_id'])    
-    JBoxContainer.configure(dckr, cfg['docker_image'], cfg['mem_limit'], cfg['cpu_limit'], [os.path.join(backup_location, '${CNAME}')], backup_location, cfg['numlocalmax'], cfg['disk_limit'], backup_bucket=backup_bucket)
+    JBoxContainer.configure(dckr, cfg['docker_image'], cfg['mem_limit'], cfg['cpu_limit'], cfg['disk_limit'], 
+                            [os.path.join(mnt_location, '${DISK_ID}')], mnt_location, backup_location, user_home_img, 
+                            cfg['numlocalmax'], cfg["numdisksmax"], backup_bucket=backup_bucket)
 
     # backup user files every 1 hour
     # check: configured expiry time must be at least twice greater than this
     run_interval = int(cfg['delete_stopped_timeout'])/2
-    if run_interval < 5*60:
-        run_interval = 5*60
+    if run_interval < 3*60:
+        run_interval = 3*60
         
     log_info("Backup interval: " + str(run_interval/60) + " minutes")
     log_info("Stopped containers would be deleted after " + str(int(cfg['delete_stopped_timeout'])/60) + " minutes")

--- a/host/tornado/src/jbox.py
+++ b/host/tornado/src/jbox.py
@@ -153,7 +153,7 @@ class MainHandler(tornado.web.RequestHandler):
             self.set_header('Connection', 'close')
             self.request.connection.no_keep_alive = True
             if nhops > cfg['numhopmax']:
-                rendertpl(self, "index.tpl", cfg=cfg, state=state.state(error="Maximum number of JuliaBox instances active. Please try after sometime.", success=''))
+                rendertpl(self, "index.tpl", cfg=cfg, state=self.state(error="Maximum number of JuliaBox instances active. Please try after sometime.", success=''))
             else:
                 self.redirect('/?h=' + str(nhops+1))
         else:
@@ -476,9 +476,13 @@ if __name__ == "__main__":
     CloudHelper.configure(has_s3=cloud_cfg['s3'], has_dynamodb=cloud_cfg['dynamodb'], has_cloudwatch=cloud_cfg['cloudwatch'], region=cloud_cfg['region'], install_id=cloud_cfg['install_id'])
     
     backup_location = os.path.expanduser(cfg['backup_location'])
+    user_home_img = os.path.expanduser(cfg['user_home_image'])
+    mnt_location = os.path.expanduser(cfg['mnt_location'])
     backup_bucket = cloud_cfg['backup_bucket']
     make_sure_path_exists(backup_location)
-    JBoxContainer.configure(dckr, cfg['docker_image'], cfg['mem_limit'], cfg['cpu_limit'], [os.path.join(backup_location, '${CNAME}')], backup_location, cfg['numlocalmax'], cfg['disk_limit'], backup_bucket=backup_bucket)
+    JBoxContainer.configure(dckr, cfg['docker_image'], cfg['mem_limit'], cfg['cpu_limit'], cfg['disk_limit'], 
+                            [os.path.join(mnt_location, '${DISK_ID}')], mnt_location, backup_location, user_home_img, 
+                            cfg['numlocalmax'], cfg["numdisksmax"], backup_bucket=backup_bucket)
     JBoxContainer.publish_container_stats()
     
     JBoxUserV2._init(table_name=cloud_cfg.get('jbox_users_v2', 'jbox_users_v2'), enckey=cfg['sesskey'])
@@ -498,8 +502,8 @@ if __name__ == "__main__":
     
     ioloop = tornado.ioloop.IOLoop.instance()
 
-    # run container maintainence every 10 minutes
-    run_interval = 10*60*1000
+    # run container maintainence every 5 minutes
+    run_interval = 5*60*1000
     log_info("Container maintenance every " + str(run_interval/(60*1000)) + " minutes")
     ct = tornado.ioloop.PeriodicCallback(do_housekeeping, run_interval, ioloop)
     ct.start()


### PR DESCRIPTION
Implemented a form of flexible disk limits using a combination of:
- mounting an external/loopback volume of an appropriate size as the user home
- devicemapper as storage backend and its max container size configuration to impose a maximum limit of data written at places other than the user home (primarily `/var/log`, `/tmp`, etc.)

The devicemapper `loopdatasize` must be configured to a value such that it will run out of space only if all running containers exceed their allowed capacity. This would ensure no single container can jeopardize all other containers.

Current implementation precreates uniformly sized loopback volumes to mount as user home. This can later be enhanced to have an external allocator/manager process for creation/reuse/destruction of volumes.
