### PR TITLE
make session names unique

### DIFF
--- a/host/tornado/src/handlers/main.py
+++ b/host/tornado/src/handlers/main.py
@@ -7,7 +7,7 @@ from oauth2client.client import OAuth2Credentials
 
 from handlers.handler_base import JBoxHandler
 
-from jbox_util import esc_sessname, CloudHelper
+from jbox_util import unique_sessname, CloudHelper
 from jbox_crypto import signstr
 from handlers.auth import AuthHandler
 from db.user_v2 import JBoxUserV2
@@ -41,7 +41,7 @@ class MainHandler(JBoxHandler):
             self.rendertpl("index.tpl", cfg=self.config(), state=state)
         else:
             user_id = jbox_cookie['u']
-            sessname = esc_sessname(user_id)
+            sessname = unique_sessname(user_id)
 
             if self.config("gauth"):
                 try:

--- a/host/tornado/src/handlers/ping.py
+++ b/host/tornado/src/handlers/ping.py
@@ -2,7 +2,7 @@ import tornado
 import tornado.web
 import tornado.gen
 
-from jbox_util import esc_sessname
+from jbox_util import unique_sessname
 from handlers.handler_base import JBoxHandler
 from jbox_container import JBoxContainer
 
@@ -13,7 +13,7 @@ class PingHandler(JBoxHandler):
     def get(self):
         sessname = str(self.get_cookie("sessname")).replace('"', '')
         if self.is_valid_req(self):
-            JBoxContainer.record_ping("/" + esc_sessname(sessname))
+            JBoxContainer.record_ping("/" + unique_sessname(sessname))
             self.set_status(status_code=204)
             self.finish()
         else:


### PR DESCRIPTION
Use sha1 hash of user email as part of sessionid.
This avoids possible sessionid clash between two closely resembling email ids.
