### PR TITLE
websocket uses dns name from route53 if configured

### DIFF
--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -1,5 +1,0 @@
-ACKNOWLEDGEMENTS 
-
-- Docker
-- OpenResty
-- Lua Resty HTTP Client

--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,7 @@
+## Acknowledgements 
+
+Code examples from the below projects/websites have been used:
+- Docker - <http://www.docker.io/>
+- OpenResty - <http://openresty.org/>
+- Lua Resty HTTP Client - <https://github.com/bakins/lua-resty-http-simple>
+

--- a/README.md
+++ b/README.md
@@ -21,88 +21,30 @@
     - Open up ports 22 (ssh), 80 (http), 443 (https) in the security group for both incoming and outgoing traffic. 
     - Open outgoing UDP port 53 (dns), if machine is configured inside a VPC.
     - Optionally open outgoing port 9418 (git).
-- On a 14.04 system, make sure your id has `sudo` permissions.
-- Run the following:
-    - `sudo apt-get install git`
-    - `git clone https://github.com/JuliaLang/JuliaBox.git`
-    - `cd JuliaBox`
-- JuliaBox uses Amazon DynamoDB to store user credentials, S3 to store user data, and Python Boto package to access AWS. To set them up:
-    - Log in to Amazon AWS.
-    - Create a DynamoDB table named `jbox_users` with hash key attribute `user_id`.
-    - Create a S3 bucket named `juliabox-userbackup`.
-    - Create a Amazon IAM user named `juliabox` and get the AWS credentials for the user.
-    - Grant read and write permissions to `juliabox` user for `jbox_users` DynamoDB table and `juliabox-userbackup` S3 bucket.
+- Clone JuliaBox (`sudo apt-get install git; git clone https://github.com/JuliaLang/JuliaBox.git`)
+- JuliaBox uses Amazon DynamoDB to store user credentials, S3 to store user data, and Python Boto package to access AWS. Set them up from a script or AWS console:
+    - Create a Amazon IAM user named `juliabox` and get the AWS credentials for the user. Grant appropriate permissions to the user.
     - Create a boto configuration file with the above AWS credentials as described here: <http://boto.readthedocs.org/en/latest/boto_config_tut.html>.
-- Run `setup.sh` with appropriate options.
-    - `admin_username` above is the session name for an "administration" session. If not using Google auth, select something non-guessable.
-    - Go get a coffee, this will take a while
-
-
-Options available with `setup.sh`:
-
-```
-Usage: ./setup.sh -u <admin_username> optional_args
- -u  <username> : Mandatory admin username. If -g option is used, this must be the complete Google email-id
- -g             : Use Google OAuth2 for user authentication. Options -k and -s must be specified.
- -k  <key>      : Google OAuth2 key (client id).
- -s  <secret>   : Google OAuth2 client secret.
- -d             : Only recreate docker image - do not install/update other software
- -n  <num>      : Maximum number of active containers. Deafult 10.
- -t  <seconds>  : Auto delete containers older than specified seconds. 0 means never expire. Default 0.
-```
+    - Create DynamoDB tables for tables used from `db/*.py` sources.
+    - Create a S3 bucket named `juliabox-userbackup`.
+- Use scripts from [install folder](scripts/README.md) to complete the installation.
 
 
 ### Powering up
 
 - `cd <path to JuliaBox>`
 - Optionally create a file named `jbox.user` that contain a subset of parameters from `host/tornado/conf/tornado.conf` that you wish to customize
-- `./start.sh`
+- Use scripts from [run folder](scripts/README.md) to start and stop the server.
+- Start the server with `./scripts/run/start.sh`
 - Point your browser to `http://<your_host_address>/`
-- `stop.sh` stops nginx and tornado, while `reload.sh` restarts the servers
-
-### Server Maintenance
-
-If you are just updating JuliaBox and do not wish to reinstall packages on your host, use the `-d` option. This will just apply any changes to the scripts and nginx config files. Any changes to your nginx config file will be overwritten.
-
-```
-git pull
-
-./setup.sh -u <admin_username> -d 
-
-./reload.sh
-```
-
-You may also change parameters in `jbox.user` and run `reload.sh` for the changed parameters to take affect
-
-To get the latest Julia build onto the docker image, you have have to build it with the `-no-cache` option. E.g. `sudo docker build -no-cache ...`.
-
-User containers are backed up and removed from docker after configured inactivity time. They are re-constituted when a user returns and the backed up files are restored into the new container instance. Location where containers are backed up can be configured via parameter `backup_location`.
-
-Unwanted/old images take up unecessary disk space. To clear them run `sudo docker rmi $(sudo docker images | grep "^<none>" | tr -s ' ' | cut -d ' ' -f 3)`.
+- Stop the server with `./scripts/run/stop.sh`, and restart it with `./scripts/run/reload.sh`. You may change parameters in `jbox.user` and run `reload.sh` for them to take effect.
 
 
 ### TODO
-- Limiting disk usage by session.
 - Creating/selecting a custom image that has been extended from the base JuliaBox provided image.
 - Upload .ipynb notebooks by URLs directly into the container.
 - Security improvements.
 - More complete Admin interface.
 - Prettier UI. Help/tips for users.
 - Launching remote docker instances.
-
-
-### Notes
-
-- On EC2, the containers are created on the ephemeral volume. They do not persist across a system start/stop
-- NGINX and embedded Lua (from <http://openresty.org/>) and tornado have been used to build the web interface
-- Not recommended to host on the public internet just yet. 
-- Security is mostly a TODO at this time.
-- Docker itself is undergoing changes in its API. Since we pull in the latest docker, changes in the docker API may break JuliaBox at any time.
-  
-## Acknowledgements 
-
-Code examples from the below projects/websites have been used:
-- Docker - <http://www.docker.io/>
-- OpenResty - <http://openresty.org/>
-- Lua Resty HTTP Client - <https://github.com/bakins/lua-resty-http-simple>
 

--- a/host/tornado/src/handlers/cors.py
+++ b/host/tornado/src/handlers/cors.py
@@ -25,6 +25,6 @@ class CorsHandler(JBoxHandler):
             for cname in ['sessname', 'hostshell', 'hostupload', 'hostipnb', 'sign', 'juliabox']:
                 args[cname] = self.get_cookie(cname)
             args = tornado.escape.url_escape(base64.b64encode(encrypt(json.dumps(args), self.config(key='sesskey'))))
-            url = "//" + CloudHelper.instance_public_hostname() + "/cors/?m=" + args
+            url = "//" + CloudHelper.notebook_websocket_hostname() + "/cors/?m=" + args
             self.log_debug("redirecting to " + url)
             self.redirect(url)

--- a/host/tornado/src/jbox_container.py
+++ b/host/tornado/src/jbox_container.py
@@ -429,7 +429,7 @@ class JBoxContainer(LoggerMixin):
         nbconfig = os.path.join(disk_path, '.ipython/profile_julia/ipython_notebook_config.py')
         with open(nbconfig, "a") as nbconfig_file:
             nbconfig_file.write(
-                "c.NotebookApp.websocket_url = 'ws://" + CloudHelper.instance_public_hostname() + "'\n")
+                "c.NotebookApp.websocket_url = 'ws://" + CloudHelper.notebook_websocket_hostname() + "'\n")
 
     def restore_backup_to_disk(self, disk_path, old_backup):
         cname = self.get_name()

--- a/host/tornado/src/jbox_util.py
+++ b/host/tornado/src/jbox_util.py
@@ -171,6 +171,12 @@ class CloudHelper(LoggerMixin):
         return CloudHelper.INSTANCE_ID
 
     @staticmethod
+    def notebook_websocket_hostname():
+        if CloudHelper.ENABLED['route53']:
+            return CloudHelper.make_instance_dns_name()
+        return CloudHelper.instance_public_hostname()
+
+    @staticmethod
     def instance_public_hostname():
         if CloudHelper.PUBLIC_HOSTNAME is None:
             if not CloudHelper.ENABLED['cloudwatch']:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,4 +10,3 @@
 - `run/stop.sh`
 - `run/reload.sh`: Re-start the server and apply any changes made to configuration.
 - `run/clean.sh`: Remove all log files.
-- 


### PR DESCRIPTION
This will enable serving notebooks on HTTPS.
Also updated readme.
