### PR TITLE
update julia packages on running instances

### DIFF
--- a/host/tornado/src/db/dynconfig.py
+++ b/host/tornado/src/db/dynconfig.py
@@ -127,3 +127,24 @@ class JBoxDynConfig(JBoxDB):
             JBoxDynConfig.table().delete_item(name='.'.join([cluster, 'message']))
 
         return None
+
+    @staticmethod
+    def get_user_home_image(cluster):
+        try:
+            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_home_image'))
+        except boto.dynamodb2.exceptions.ItemNotFound:
+            return None, None
+        img = json.loads(record.get_value())
+        return img['bucket'], img['filename']
+
+    @staticmethod
+    def set_user_home_image(cluster, bucket, filename):
+        img = {
+            'bucket': bucket,
+            'filename': filename
+        }
+        img = json.dumps(img)
+        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_home_image'), create=True, value=img)
+        if not record.is_new:
+            record.set_value(img)
+            record.save()

--- a/host/tornado/src/jbox.py
+++ b/host/tornado/src/jbox.py
@@ -75,11 +75,20 @@ class JBox(LoggerMixin):
             CloudHost.log_info("No prior dns registration found for the instance")
         CloudHost.register_instance_dns()
         JBoxContainer.publish_container_stats()
+        JBox.do_update_user_home_image()
         self.ct.start()
         self.ioloop.start()
 
     @staticmethod
+    def do_update_user_home_image():
+        if VolMgr.has_update_for_user_home_image():
+            if not VolMgr.update_user_home_image(fetch=False):
+                JBoxContainer.async_update_user_home_image()
+
+    @staticmethod
     def do_housekeeping():
+        JBox.do_update_user_home_image()
+
         server_delete_timeout = JBox.cfg['expire']
         JBoxContainer.maintain(max_timeout=server_delete_timeout, inactive_timeout=JBox.cfg['inactivity_timeout'],
                                protected_names=JBox.cfg['protected_docknames'])

--- a/host/tornado/src/jbox_container.py
+++ b/host/tornado/src/jbox_container.py
@@ -119,6 +119,11 @@ class JBoxContainer(LoggerMixin):
         return cont
 
     @staticmethod
+    def async_update_user_home_image():
+        JBoxContainer.log_info("scheduling update of user home image")
+        JBoxContainer.ASYNC_JOB.send(JBoxAsyncJob.CMD_UPDATE_USER_HOME_IMAGE, '')
+
+    @staticmethod
     def async_schedule_activations():
         JBoxContainer.log_info("scheduling activations")
         JBoxContainer.ASYNC_JOB.send(JBoxAsyncJob.CMD_AUTO_ACTIVATE, '')

--- a/host/tornado/src/jbox_util.py
+++ b/host/tornado/src/jbox_util.py
@@ -209,6 +209,7 @@ class JBoxAsyncJob(LoggerMixin):
     CMD_BACKUP_CLEANUP = 1
     CMD_LAUNCH_SESSION = 2
     CMD_AUTO_ACTIVATE = 3
+    CMD_UPDATE_USER_HOME_IMAGE = 4
 
     def __init__(self, port, mode):
         self._mode = mode

--- a/host/tornado/src/jboxd.py
+++ b/host/tornado/src/jboxd.py
@@ -153,6 +153,13 @@ class JBoxd(LoggerMixin):
         finally:
             JBoxd.finish_thread()
 
+    @staticmethod
+    def update_user_home_image():
+        try:
+            VolMgr.update_user_home_image(fetch=True)
+        finally:
+            JBoxd.finish_thread()
+
     def run(self):
         while True:
             self.log_debug("JBox daemon waiting for commands...")
@@ -167,6 +174,9 @@ class JBoxd(LoggerMixin):
             elif cmd == JBoxAsyncJob.CMD_AUTO_ACTIVATE:
                 args = ()
                 fn = JBoxd.auto_activate
+            elif cmd == JBoxAsyncJob.CMD_UPDATE_USER_HOME_IMAGE:
+                args = ()
+                fn = JBoxd.update_user_home_image
             else:
                 self.log_error("Unknown command " + str(cmd))
                 continue

--- a/scripts/install/upload_user_home.py
+++ b/scripts/install/upload_user_home.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import db
+from db import JBoxDynConfig
+from jbox_util import read_config, LoggerMixin
+import docker
+from cloud.aws import CloudHost
+from vol import VolMgr, JBoxVol
+
+if __name__ == "__main__":
+    dckr = docker.Client()
+    cfg = read_config()
+    cloud_cfg = cfg['cloud_host']
+
+    LoggerMixin.setup_logger(level=cfg['root_log_level'])
+    LoggerMixin.DEFAULT_LEVEL = cfg['jbox_log_level']
+
+    db.configure_db(cfg)
+
+    CloudHost.configure(has_s3=cloud_cfg['s3'],
+                        has_dynamodb=cloud_cfg['dynamodb'],
+                        has_cloudwatch=cloud_cfg['cloudwatch'],
+                        has_autoscale=cloud_cfg['autoscale'],
+                        has_route53=cloud_cfg['route53'],
+                        has_ebs=cloud_cfg['ebs'],
+                        has_ses=cloud_cfg['ses'],
+                        scale_up_at_load=cloud_cfg['scale_up_at_load'],
+                        scale_up_policy=cloud_cfg['scale_up_policy'],
+                        autoscale_group=cloud_cfg['autoscale_group'],
+                        route53_domain=cloud_cfg['route53_domain'],
+                        region=cloud_cfg['region'],
+                        install_id=cloud_cfg['install_id'])
+
+    VolMgr.configure(dckr, cfg)
+    ts = JBoxVol._get_user_home_timestamp()
+    VolMgr.log_debug("user_home_timestamp: %s", ts.strftime("%Y%m%d_%H%M"))
+
+    img_dir, img_file = os.path.split(JBoxVol.USER_HOME_IMG)
+    new_img_file_name = 'user_home_' + ts.strftime("%Y%m%d_%H%M") + '.tar.gz'
+    new_img_file = os.path.join(img_dir, new_img_file_name)
+    shutil.copyfile(JBoxVol.USER_HOME_IMG, new_img_file)
+
+    VolMgr.log_debug("new image file is at : %s", new_img_file)
+
+    bucket = 'juliabox-user-home-templates'
+
+    VolMgr.log_debug("pushing new image file to s3 at: %s", bucket)
+    CloudHost.push_file_to_s3(bucket, new_img_file)
+
+    for cluster in ['JuliaBoxTest', 'JuliaBox']:
+        VolMgr.log_debug("setting image for cluster: %s", cluster)
+        JBoxDynConfig.set_user_home_image(cluster, bucket, new_img_file_name)

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -66,6 +66,10 @@ class TestDBTables(LoggerMixin):
         JBoxDynConfig.set_message(TESTCLSTR, "hello world", datetime.timedelta(minutes=1))
         assert JBoxDynConfig.get_message(TESTCLSTR) == "hello world"
 
+        JBoxDynConfig.set_user_home_image(TESTCLSTR, "juliabox-user-home-templates", "user_home_28Nov2014.tar.gz")
+        assert JBoxDynConfig.get_user_home_image(TESTCLSTR) == ("juliabox-user-home-templates",
+                                                                "user_home_28Nov2014.tar.gz")
+
         num_pending_activations = JBoxUserV2.count_pending_activations()
         TestDBTables.log_debug("pending activations: %d", num_pending_activations)
 
@@ -73,5 +77,19 @@ class TestDBTables(LoggerMixin):
         result_arr = [obj for obj in resultset]
         TestDBTables.log_debug("got array: %r", result_arr)
 
+
+class TestSES(LoggerMixin):
+    @staticmethod
+    def test():
+        CloudHost.send_email('tanmaykm@gmail.com', 'admin@juliabox.org', "test SES",
+                             """hello world
+                             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+                             ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                             ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+                             reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+                             anim id est laborum.""")
+
 if __name__ == "__main__":
     TestDBTables.test()
+    TestSES.test()


### PR DESCRIPTION
Updates to Julia packages and user home image are now delivered through S3
and will not require creating a new AWS image any more.

Images are built and provisioned on S3 from any build machine.

Latest configured image is pulled on startup of a new ec2 instance and periodically on all
running ec2 instances.
