### PR TITLE
console color scheme selectable (default dark)

### DIFF
--- a/docker/IJulia/supervisord.conf
+++ b/docker/IJulia/supervisord.conf
@@ -4,7 +4,7 @@ logfile_maxbytes = 1MB
 logfile_backups = 2
 
 [program:shellinabox]
-command=shellinaboxd -t -s /:juser:juser:/home/juser:/bin/bash
+command=shellinaboxd -t -s /:juser:juser:/home/juser:/bin/bash --user-css Light:-/usr/local/share/doc/shellinabox/black-on-white.css,Dark:+/usr/local/share/doc/shellinabox/white-on-black.css
 stdout_logfile = /home/juser/.juliabox/shellinabox.log
 stdout_logfile_backups = 2
 stdout_logfile_maxbytes = 1MB


### PR DESCRIPTION
Console color scheme can be selected from a menu that appears with a right click.
Available schemes:
- Dark (dark background with light fonts) - default
- Light (light background with dark fonts)

Also needed https://github.com/tanmaykm/shellinabox_fork/commit/8d2a31df39e3097bcf5e56e6252372655233ca11
and https://github.com/tanmaykm/shellinabox_fork/commit/8e3a8c2943c97dea98621236cfbc7c20aedcccf7

ref: #67 
