### PR TITLE
ipython changes to fix notebook export. fixes #162

### DIFF
--- a/docker/IJulia/Dockerfile
+++ b/docker/IJulia/Dockerfile
@@ -1,7 +1,7 @@
 # Docker file for JuliaBox
-# Version:19
+# Version:20
 
-FROM tanmaykm/jboxjulia:v0.3.3_10
+FROM tanmaykm/jboxjulia:v0.3.3_11
 
 MAINTAINER Tanmay Mohapatra
 

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,5 +1,5 @@
 # Base Ubuntu Docker file for JuliaBox
-# Version:8
+# Version:9
 
 FROM stackbrew/ubuntu:trusty
 
@@ -57,9 +57,17 @@ RUN cd /tmp/tl; wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx
     echo "export MANPATH=/usr/local/texlive/2014/texmf-dist/doc/man:\$MANPATH" >>  /etc/profile.d/texlive.sh; \
     chmod 755 /etc/profile.d/texlive.sh
 
+#RUN cd /tmp/tl; git clone https://github.com/scottkosty/install-tl-ubuntu.git; \
+#    ./install-tl-ubuntu/install-tl-ubuntu --allow-small --profile /tmp/tl/texlive.profile --retry 5; \
+#    cd /; rm -rf /tmp/tl; \
+#    echo "export PATH=/usr/local/texlive/2014/bin/x86_64-linux:\$PATH" > /etc/profile.d/texlive.sh; \
+#    echo "export INFOPATH=/usr/local/texlive/2014/texmf-dist/doc/info:\$INFOPATH" >> /etc/profile.d/texlive.sh; \
+#    echo "export MANPATH=/usr/local/texlive/2014/texmf-dist/doc/man:\$MANPATH" >>  /etc/profile.d/texlive.sh; \
+#    chmod 755 /etc/profile.d/texlive.sh
+
 RUN pip install --upgrade PyDrive google-api-python-client jsonpointer jsonschema tornado sphinx pygments nose readline mistune
 
-RUN git clone --recursive https://github.com/tanmaykm/ipython.git; cd ipython; python setup.py install; cd ..; rm -rf ipython
+RUN git clone --recursive https://github.com/tanmaykm/ipython.git; cd ipython; git checkout juliabox; python setup.py install; cd ..; rm -rf ipython
 
 RUN git clone https://github.com/tanmaykm/shellinabox_fork.git; cd shellinabox_fork; ./configure; make install; cd ..; rm -rf shellinabox_fork
 

--- a/docker/julia_v0.3/Dockerfile
+++ b/docker/julia_v0.3/Dockerfile
@@ -1,7 +1,7 @@
 # Base Dockerfile with Julia 0.3 release
-# Version:10
+# Version:11
 
-FROM tanmaykm/jboxcore:8
+FROM tanmaykm/jboxcore:9
 
 MAINTAINER Tanmay Mohapatra
 

--- a/docker/mk_user_home.sh
+++ b/docker/mk_user_home.sh
@@ -21,8 +21,8 @@ ${SUDO_JUSER} mkdir -p ${JUSER_HOME}/.ipython/kernels/julia
 ${SUDO_JUSER} cat > ${JUSER_HOME}/.ipython/kernels/julia/kernel.json <<EOF
 {
         "argv": ["/usr/bin/julia", "-F", "/home/juser/.julia/v0.3/IJulia/src/kernel.jl", "{connection_file}"],
-        "codemirror_mode": {   "version": 0.3,   "name": "julia"  },
-        "display_name": "IJulia (Julia 0.3)",
+        "codemirror_mode": "julia",
+        "display_name": "Julia",
         "language": "julia"
 }
 EOF


### PR DESCRIPTION
IPython was broken as `mistune` got updated to `0.5`.
JuliaBox IPython fork fixed (https://github.com/tanmaykm/ipython/commit/5e95f88987c015ef2881716c7243c0a2127112ea) and docker build updated.

Could not move to current IPython dev branch as notebook upgrade doesn't seem to be working fine yet,
and upgraded JuliaBox notebooks won't open on the IPython released version (which will be the
most common version installed by users locally).
