### PR TITLE
Julia 0.3.4 update and packages precompiled into custom system image 

### DIFF
--- a/docker/IJulia/Dockerfile
+++ b/docker/IJulia/Dockerfile
@@ -1,7 +1,7 @@
 # Docker file for JuliaBox
-# Version:21
+# Version:22
 
-FROM tanmaykm/jboxjulia:v0.3.3_11
+FROM tanmaykm/jboxjulia:v0.3.4_12
 
 MAINTAINER Tanmay Mohapatra
 
@@ -81,10 +81,6 @@ RUN apt-get install -y \
     libgvc6 \
     graphviz \
     libgraphviz-dev \
-    && apt-get clean
-
-RUN apt-get install -y \
-    unzip \
     && apt-get clean
 
 # add juser

--- a/docker/build_sysimg.jl
+++ b/docker/build_sysimg.jl
@@ -1,0 +1,168 @@
+#!/usr/bin/env julia
+
+# Build a system image binary at sysimg_path.dlext.  By default, put the system image
+# next to libjulia (except on Windows, where it goes in $JULIA_HOME\..\lib\julia)
+# Allow insertion of a userimg via userimg_path.  If sysimg_path.dlext is currently loaded into memory,
+# don't continue unless force is set to true.  Allow targeting of a CPU architecture via cpu_target
+@unix_only const default_sysimg_path = joinpath(dirname(Sys.dlpath("libjulia")),"sys")
+@windows_only const default_sysimg_path = joinpath(JULIA_HOME,"..","lib","julia","sys")
+function build_sysimg(sysimg_path=default_sysimg_path, cpu_target="native", userimg_path=nothing; force=false)
+    # Quit out if a sysimg is already loaded and is in the same spot as sysimg_path, unless forcing
+    sysimg = dlopen_e("sys")
+    if sysimg != C_NULL
+        if !force && Base.samefile(Sys.dlpath(sysimg), "$(sysimg_path).$(Sys.dlext)")
+            info("System image already loaded at $(Sys.dlpath(sysimg)), set force to override")
+            return
+        end
+    end
+
+    # Canonicalize userimg_path before we enter the base_dir
+    if userimg_path != nothing
+        userimg_path = abspath(userimg_path)
+    end
+
+    # Enter base/ and setup some useful paths
+    base_dir = dirname(Base.find_source_file("sysimg.jl"))
+    cd(base_dir) do
+        try
+            julia = joinpath(JULIA_HOME, "julia")
+            ld = find_system_linker()
+
+            # Ensure we have write-permissions to wherever we're trying to write to
+            try
+                touch("$sysimg_path.ji")
+            catch
+                err_msg =  "Unable to modify $sysimg_path.ji, ensure parent directory exists "
+                err_msg *= "and is writable. Absolute paths work best. Do you need to run this with sudo?)"
+                error( err_msg )
+            end
+
+            # Copy in userimg.jl if it exists...
+            if userimg_path != nothing
+                if !isreadable(userimg_path)
+                    error("$userimg_path is not readable, ensure it is an absolute path!")
+                end
+                cp(userimg_path, "userimg.jl")
+            end
+
+            # Start by building sys0.{ji,o}
+            sys0_path = joinpath(dirname(sysimg_path), "sys0")
+            info("Building sys0.o...")
+            println("$julia -C $cpu_target --build $sys0_path sysimg.jl")
+            run(`$julia -C $cpu_target --build $sys0_path sysimg.jl`)
+
+            # Bootstrap off of that to create sys.{ji,o}
+            info("Building sys.o...")
+            println("$julia -C $cpu_target --build $sysimg_path -J $sys0_path.ji -f sysimg.jl")
+            run(`$julia -C $cpu_target --build $sysimg_path -J $sys0_path.ji -f sysimg.jl`)
+
+            if ld != nothing
+                link_sysimg(sysimg_path, ld)
+            else
+                info("System image successfully built at $sysimg_path.ji")
+            end
+
+            if !Base.samefile("$default_sysimg_path.ji", "$sysimg_path.ji")
+                info("To run Julia with this image loaded, run: julia -J $sysimg_path.ji")
+            else
+                info("Julia will automatically load this system image at next startup")
+            end
+        finally
+            # Cleanup userimg.jl
+            if isfile("userimg.jl")
+                rm("userimg.jl")
+            end
+        end
+    end
+end
+
+# Search for a linker to link sys.o into sys.dl_ext.  Honor LD environment variable.
+function find_system_linker()
+    if haskey( ENV, "LD" )
+        if !success(`$(ENV["LD"]) -v`)
+            warn("Using linker override $(ENV["LD"]), but unable to run `$(ENV["LD"]) -v`")
+        end
+        return ENV["LD"]
+    end
+
+    # On Windows, check to see if WinRPM is installed, and if so, see if gcc is installed
+    @windows_only try
+        require("WinRPM")
+        winrpmgcc = joinpath(WinRPM.installdir,"usr","$(Sys.ARCH)-w64-mingw32",
+            "sys-root","mingw","bin","gcc.exe")
+        if success(`$winrpmgcc --version`)
+            return winrpmgcc
+        else
+            throw()
+        end
+    catch
+        warn("Install GCC via `Pkg.add(\"WinRPM\"); WinRPM.install(\"gcc\")` to generate sys.dll for faster startup times")
+    end
+
+
+    # See if `ld` exists
+    try
+        if success(`ld -v`)
+            return "ld"
+        end
+    end
+
+    warn( "No supported linker found; startup times will be longer" )
+end
+
+# Link sys.o into sys.$(dlext)
+function link_sysimg(sysimg_path=default_sysimg_path, ld=find_system_linker())
+    julia_libdir = dirname(Sys.dlpath("libjulia"))
+
+    FLAGS = ["-L$julia_libdir"]
+    if OS_NAME == :Darwin
+        push!(FLAGS, "-dylib")
+        push!(FLAGS, "-undefined")
+        push!(FLAGS, "dynamic_lookup")
+        push!(FLAGS, "-macosx_version_min")
+        push!(FLAGS, "10.7")
+    else
+        push!(FLAGS, "-shared")
+        # on windows we link using gcc for now
+        wl = @windows? "-Wl," : ""
+        push!(FLAGS, wl * "--unresolved-symbols")
+        push!(FLAGS, wl * "ignore-all")
+    end
+    @windows_only append!(FLAGS, ["-ljulia", "-lssp-0"])
+
+    info("Linking sys.$(Sys.dlext)")
+    run(`$ld $FLAGS -o $sysimg_path.$(Sys.dlext) $sysimg_path.o`)
+
+    info("System image successfully built at $sysimg_path.$(Sys.dlext)")
+    @windows_only begin
+        if convert(VersionNumber, Base.libllvm_version) < v"3.5.0"
+            LLVM_msg = "Building sys.dll on Windows against LLVM < 3.5.0 can cause incorrect backtraces!"
+            LLVM_msg *= " Delete generated sys.dll to avoid these problems"
+            warn( LLVM_msg )
+        end
+    end
+end
+
+# When running this file as a script, try to do so with default values.  If arguments are passed
+# in, use them as the arguments to build_sysimg above
+if !isinteractive()
+    if length(ARGS) > 4 || ("--help" in ARGS || "-h" in ARGS)
+        println("Usage: build_sysimg.jl <sysimg_path> <cpu_target> <usrimg_path.jl> [--force] [--help]")
+        println("   <sysimg_path>    is an absolute, extensionless path to store the system image at")
+        println("   <cpu_target>     is an LLVM cpu target to build the system image against")
+        println("   <usrimg_path.lj> is the path to a user image to be baked into the system image")
+        println("   --force          Set if you wish to overwrite the default system image")
+        println("   --help           Print out this help text and exit")
+        println()
+        println(" Example:")
+        println("   build_sysimg.jl /usr/local/lib/julia/sys core2 ~/my_usrimg.jl true")
+        println()
+        println(" Running this script with no arguments is equivalent to calling it via")
+        println("   build_sysimg.jl $(default_sysimg_path) native")
+        return 0
+    end
+
+    force_flag = "--force" in ARGS
+    filter!(x -> x != "--force", ARGS)
+    build_sysimg(ARGS..., force=force_flag)
+end

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,5 +1,5 @@
 # Base Ubuntu Docker file for JuliaBox
-# Version:9
+# Version:10
 
 FROM stackbrew/ubuntu:trusty
 
@@ -20,6 +20,7 @@ RUN apt-get update \
     vim \
     screen \
     tmux \
+    unzip \
     pkg-config \
     pandoc \
     pdf2svg \

--- a/docker/jimg.jl
+++ b/docker/jimg.jl
@@ -1,0 +1,2 @@
+include(joinpath(Pkg.dir("Gadfly"), "src/Gadfly.jl"))
+importall Gadfly

--- a/docker/julia_v0.3/Dockerfile
+++ b/docker/julia_v0.3/Dockerfile
@@ -1,7 +1,7 @@
 # Base Dockerfile with Julia 0.3 release
-# Version:11
+# Version:12
 
-FROM tanmaykm/jboxcore:9
+FROM tanmaykm/jboxcore:10
 
 MAINTAINER Tanmay Mohapatra
 
@@ -10,6 +10,5 @@ RUN apt-get install -y -o Dpkg::Options::="--force-confdef" -o DPkg::Options::="
     && apt-add-repository -y ppa:staticfloat/juliareleases \
     && add-apt-repository -y ppa:staticfloat/julia-deps \
     && apt-get update \
-    && apt-get install -y julia=0.3.3~trusty1 \
+    && apt-get install -y julia=0.3.4~trusty1 \
     && apt-get clean
-

--- a/docker/mk_user_home.sh
+++ b/docker/mk_user_home.sh
@@ -12,10 +12,19 @@ function error_exit {
 
 sudo rm -rf ${JUSER_HOME}
 mkdir -p ${JUSER_HOME}
+mkdir -p ${JUSER_HOME}/.juliabox
+mkdir -p ${JUSER_HOME}/.juliabox/jimg
+
 cp ${DIR}/setup_julia.sh ${JUSER_HOME}
+cp ${DIR}/build_sysimg.jl ${JUSER_HOME}
+cp ${DIR}/jimg.jl ${JUSER_HOME}
+cp ${DIR}/mkjimg.jl ${JUSER_HOME}
+
 sudo chown -R 1000:1000 ${JUSER_HOME}
 sudo docker run -i -v ${JUSER_HOME}:/home/juser --entrypoint="/home/juser/setup_julia.sh" juliabox/juliabox:latest || error_exit "Could not run juliabox image"
-${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh
+sudo docker run -i -v ${JUSER_HOME}:/home/juser --user=root --workdir=/home/juser --entrypoint="julia" juliabox/juliabox:latest mkjimg.jl || error_exit "Could not run juliabox image"
+sudo chown -R 1000:1000 ${JUSER_HOME}
+${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh ${JUSER_HOME}/build_sysimg.jl ${JUSER_HOME}/jimg.jl ${JUSER_HOME}/mkjimg.jl
 
 ${SUDO_JUSER} mkdir -p ${JUSER_HOME}/.ipython/kernels/julia
 ${SUDO_JUSER} cat > ${JUSER_HOME}/.ipython/kernels/julia/kernel.json <<EOF
@@ -32,11 +41,14 @@ echo "c.NotebookApp.ip = \"*\"" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipyt
 echo "c.NotebookApp.allow_origin = \"*\"" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_julia/ipython_notebook_config.py
 ${SUDO_JUSER} cp ${DIR}/IJulia/custom.css ${JUSER_HOME}/.ipython/profile_julia/static/custom/custom.css
 
-${SUDO_JUSER} mkdir -p ${JUSER_HOME}/.juliabox
-
 ${SUDO_JUSER} cp -R ${DIR}/IJulia/tornado ${JUSER_HOME}/.juliabox/tornado
 ${SUDO_JUSER} cp ${DIR}/IJulia/supervisord.conf ${JUSER_HOME}/.juliabox/supervisord.conf
 
 sudo rm ~/user_home.tar.gz
 sudo tar -czvf ~/user_home.tar.gz -C ${JUSER_HOME} .
 sudo rm -rf ${JUSER_HOME}
+for id in `docker ps -a | grep Exited | cut -d" " -f1 | grep -v CONTAINER`
+do
+    echo "removing $id..."
+    docker rm $id
+done

--- a/docker/mk_user_home.sh
+++ b/docker/mk_user_home.sh
@@ -26,6 +26,7 @@ sudo docker run -i -v ${JUSER_HOME}:/home/juser --user=root --workdir=/home/juse
 sudo chown -R 1000:1000 ${JUSER_HOME}
 ${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh ${JUSER_HOME}/build_sysimg.jl ${JUSER_HOME}/jimg.jl ${JUSER_HOME}/mkjimg.jl
 
+# create julia kernels
 ${SUDO_JUSER} mkdir -p ${JUSER_HOME}/.ipython/kernels/julia
 ${SUDO_JUSER} cat > ${JUSER_HOME}/.ipython/kernels/julia/kernel.json <<EOF
 {
@@ -36,10 +37,23 @@ ${SUDO_JUSER} cat > ${JUSER_HOME}/.ipython/kernels/julia/kernel.json <<EOF
 }
 EOF
 
-echo "c.NotebookApp.open_browser = False" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_julia/ipython_notebook_config.py
-echo "c.NotebookApp.ip = \"*\"" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_julia/ipython_notebook_config.py
-echo "c.NotebookApp.allow_origin = \"*\"" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_julia/ipython_notebook_config.py
-${SUDO_JUSER} cp ${DIR}/IJulia/custom.css ${JUSER_HOME}/.ipython/profile_julia/static/custom/custom.css
+#${SUDO_JUSER} mkdir -p ${JUSER_HOME}/.ipython/kernels/jboxjulia
+#${SUDO_JUSER} cat > ${JUSER_HOME}/.ipython/kernels/jboxjulia/kernel.json <<EOF
+#{
+#        "argv": ["/usr/bin/julia", "-J", "/home/juser/.juliabox/jimg/sys.ji", "-F", "/home/juser/.julia/v0.3/IJulia/src/kernel.jl", "{connection_file}"],
+#        "codemirror_mode": "julia",
+#        "display_name": "Julia(JuliaBox)",
+#        "language": "julia"
+#}
+#EOF
+
+for prof in "julia" "jboxjulia"
+do
+    echo "c.NotebookApp.open_browser = False" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_${prof}/ipython_notebook_config.py
+    echo "c.NotebookApp.ip = \"*\"" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_${prof}/ipython_notebook_config.py
+    echo "c.NotebookApp.allow_origin = \"*\"" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_${prof}/ipython_notebook_config.py
+    ${SUDO_JUSER} cp ${DIR}/IJulia/custom.css ${JUSER_HOME}/.ipython/profile_${prof}/static/custom/custom.css
+done
 
 ${SUDO_JUSER} cp -R ${DIR}/IJulia/tornado ${JUSER_HOME}/.juliabox/tornado
 ${SUDO_JUSER} cp ${DIR}/IJulia/supervisord.conf ${JUSER_HOME}/.juliabox/supervisord.conf

--- a/docker/mkjimg.jl
+++ b/docker/mkjimg.jl
@@ -2,3 +2,126 @@ require("/home/juser/build_sysimg.jl")
 
 println("Building JuliaBox Julia system image...")
 build_sysimg("/home/juser/.juliabox/jimg/sys", "native", "/home/juser/jimg.jl", force=true)
+
+# create the JuliaBox Julia profile
+# TODO: this should probably be merged with IJulia deps
+eprintln(x...) = println(STDERR, x...)
+eprintln("Creating julia profile in IPython...")
+
+include(joinpath(Pkg.dir("IJulia"), "deps", "ipython.jl"))
+const ipython, ipyvers = find_ipython()
+const profile_name = "jboxjulia"
+const custom_args = ["-J", "/home/juser/.juliabox/jimg/sys.ji"]
+
+run(`$ipython profile create $profile_name`)
+
+juliaprof = chomp(readall(`$ipython locate profile $profile_name`))
+
+function add_config(prof::String, s::String, val, overwrite=false)
+    p = joinpath(juliaprof, prof)
+    r = Regex(string("^[ \\t]*c\\.", replace(s, r"\.", "\\."), "\\s*=.*\$"), "m")
+    if isfile(p)
+        c = readall(p)
+        if ismatch(r, c)
+            m = replace(match(r, c).match, r"\s*$", "")
+            if !overwrite || m[search(m,'c'):end] == "c.$s = $val"
+                eprintln("(Existing $s setting in $prof is untouched.)")
+            else
+                eprintln("Changing $s to $val in $prof...")
+                open(p, "w") do f
+                    print(f, replace(c, r, old -> "# $old"))
+                    print(f, """
+c.$s = $val
+""")
+                end
+            end
+        else
+            eprintln("Adding $s = $val to $prof...")
+            open(p, "a") do f
+                print(f, """
+
+c.$s = $val
+""")
+            end
+        end
+    else
+        eprintln("Creating $prof with $s = $val...")
+        open(p, "w") do f
+            print(f, """
+c = get_config()
+c.$s = $val
+""")
+        end
+    end
+end
+
+# add Julia kernel manager if we don't have one yet
+if VERSION >= v"0.3-"
+    binary_name = "julia"
+else
+    binary_name = "julia-basic"
+end
+
+kernel_cmd_params = ["$(escape_string(joinpath(JULIA_HOME,(@windows? "julia.exe":"$binary_name"))))"]
+!isempty(custom_args) && append!(kernel_cmd_params, custom_args)
+append!(kernel_cmd_params, ["-i", "-F", "$(escape_string(joinpath(Pkg.dir("IJulia"),"src","kernel.jl")))", "{connection_file}"])
+kernel_cmd = "[\"$(join(kernel_cmd_params,"\",\""))\"]"
+
+add_config("ipython_config.py", "KernelManager.kernel_cmd", kernel_cmd, true)
+
+# make qtconsole require shift-enter to complete input
+add_config("ipython_qtconsole_config.py",
+           "IPythonWidget.execute_on_complete_input", "False")
+
+add_config("ipython_qtconsole_config.py",
+           "FrontendWidget.lexer_class", "'pygments.lexers.JuliaLexer'")
+
+# set Julia notebook to use a different port than IPython's 8888 by default
+add_config("ipython_notebook_config.py", "NotebookApp.port", 8998)
+
+#######################################################################
+# Copying files into the correct paths in the profile lets us override
+# the files of the same name in IPython.
+
+rb(filename::String) = open(readbytes, filename)
+eqb(a::Vector{Uint8}, b::Vector{Uint8}) =
+    length(a) == length(b) && all(a .== b)
+
+# copy IJulia/deps/src to destpath/destname if it doesn't
+# already exist at the destination, or if it has changed (if overwrite=true).
+function copy_config(src::String, destpath::String,
+                     destname::String=src, overwrite=true)
+    mkpath(destpath)
+    dest = joinpath(destpath, destname)
+    srcbytes = rb(joinpath(Pkg.dir("IJulia"), "deps", src))
+    if !isfile(dest) || (overwrite && !eqb(srcbytes, rb(dest)))
+        eprintln("Copying $src to Julia IPython profile.")
+        open(dest, "w") do f
+            write(f, srcbytes)
+        end
+    else
+        eprintln("(Existing $destname file untouched.)")
+    end
+end
+
+# copy IJulia icon to profile so that IPython will use it
+for T in ("png", "svg")
+    copy_config("ijulialogo.$T",
+                joinpath(juliaprof, "static", "base", "images"),
+                "ipynblogo.$T")
+end
+
+# copy IJulia favicon to profile
+copy_config("ijuliafavicon.ico",
+            joinpath(juliaprof, "static", "base", "images"),
+            "favicon.ico")
+
+# custom.js can contain custom js login that will be loaded
+# with the notebook to add info and/or monkey-patch some javascript
+# -- e.g. we use it to add .ipynb metadata that this is a Julia notebook
+copy_config("custom.js", joinpath(juliaprof, "static", "custom"))
+
+# julia.js implements a CodeMirror mode for Julia syntax highlighting in the notebook.
+# Eventually this will ship with CodeMirror and hence IPython, but for now we manually bundle it.
+
+copy_config("julia.js", joinpath(juliaprof, "static", "components", "codemirror", "mode", "julia"))

--- a/docker/mkjimg.jl
+++ b/docker/mkjimg.jl
@@ -1,0 +1,4 @@
+require("/home/juser/build_sysimg.jl")
+
+println("Building JuliaBox Julia system image...")
+build_sysimg("/home/juser/.juliabox/jimg/sys", "native", "/home/juser/jimg.jl", force=true)

--- a/docker/setup_julia.sh
+++ b/docker/setup_julia.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-ipython profile create julia
-
 julia -e 'Pkg.init(); Pkg.add("IJulia"); Pkg.add("PyPlot"); Pkg.add("SIUnits"); Pkg.add("Gadfly"); Pkg.add("DataStructures"); Pkg.add("HDF5"); Pkg.add("Iterators"); Pkg.add("NumericExtensions"); Pkg.add("SymPy"); Pkg.add("Interact"); Pkg.add("Roots");'
 
 julia -e 'Pkg.add("DataFrames"); Pkg.add("RDatasets"); Pkg.add("Distributions"); Pkg.add("SVM"); Pkg.add("Clustering"); Pkg.add("GLM");'

--- a/host/nginx/www/assets/js/juliabox.js
+++ b/host/nginx/www/assets/js/juliabox.js
@@ -48,6 +48,31 @@ var JuliaBox = (function($, _, undefined){
 	    	self.comm('/hostupload/sshkey', 'GET', null, s, f);
 	    },
 
+	    switch_julia_image: function(disp_curr, disp_switch) {
+	    	s = function(img){
+	    	    if(img.code == 0) {
+	    	        self.set_julia_image_type(disp_curr, disp_switch, img.data);
+	    	        bootbox.alert('Your Julia image has been changed and will be effective the next time you log in.');
+	    	    }
+	    	    else {
+	    	        bootbox.alert("Oops. Unexpected error while switching Julia image.<br/><br/>Please try again later.");
+	    	    }
+	    	};
+	    	f = function() { bootbox.alert("Oops. Unexpected error while switching Julia image.<br/><br/>Please try again later."); };
+	    	self.comm('/hostadmin/', 'GET', {'switch_julia_img': true}, s, f);
+	    },
+
+	    set_julia_image_type: function(disp_curr, disp_switch, curr_img_type) {
+	        if(0 == curr_img_type) {
+	            disp_curr.html("standard");
+	            disp_switch.html("precompiled packages");
+	        }
+	        else {
+	            disp_switch.html("standard");
+	            disp_curr.html("precompiled packages");
+	        }
+	    },
+
         _json_to_table: function(o) {
             resp = '<table class="table">';
             for(n in o) {

--- a/host/tornado/src/cloud/aws.py
+++ b/host/tornado/src/cloud/aws.py
@@ -43,6 +43,9 @@ class CloudHost(LoggerMixin):
     INSTANCE_ID = None
     INSTANCE_IMAGE_VERS = {}
     PUBLIC_HOSTNAME = None
+    LOCAL_HOSTNAME = None
+    LOCAL_IP = None
+    PUBLIC_IP = None
     SELF_STATS = {}
     # STATS_CACHE = {} # TODO: cache stats
 
@@ -88,13 +91,56 @@ class CloudHost(LoggerMixin):
         return CloudHost.instance_public_hostname()
 
     @staticmethod
-    def instance_public_hostname():
-        if CloudHost.PUBLIC_HOSTNAME is None:
-            if not CloudHost.ENABLED['cloudwatch']:
-                CloudHost.PUBLIC_HOSTNAME = 'localhost'
-            else:
-                CloudHost.PUBLIC_HOSTNAME = boto.utils.get_instance_metadata()['public-hostname']
-        return CloudHost.PUBLIC_HOSTNAME
+    def instance_public_hostname(instance_id=None):
+        if instance_id is None:
+            if CloudHost.PUBLIC_HOSTNAME is None:
+                if not CloudHost.ENABLED['cloudwatch']:
+                    CloudHost.PUBLIC_HOSTNAME = 'localhost'
+                else:
+                    CloudHost.PUBLIC_HOSTNAME = boto.utils.get_instance_metadata()['public-hostname']
+            return CloudHost.PUBLIC_HOSTNAME
+        else:
+            attrs = CloudHost.instance_attrs(instance_id)
+            return attrs.dns_name
+
+    @staticmethod
+    def instance_local_hostname(instance_id=None):
+        if instance_id is None:
+            if CloudHost.LOCAL_HOSTNAME is None:
+                if not CloudHost.ENABLED['cloudwatch']:
+                    CloudHost.LOCAL_HOSTNAME = 'localhost'
+                else:
+                    CloudHost.LOCAL_HOSTNAME = boto.utils.get_instance_metadata()['local-hostname']
+            return CloudHost.LOCAL_HOSTNAME
+        else:
+            attrs = CloudHost.instance_attrs(instance_id)
+            return attrs.private_dns_name
+
+    @staticmethod
+    def instance_public_ip(instance_id=None):
+        if instance_id is None:
+            if CloudHost.PUBLIC_IP is None:
+                if not CloudHost.ENABLED['cloudwatch']:
+                    CloudHost.PUBLIC_IP = '127.0.0.1'
+                else:
+                    CloudHost.PUBLIC_IP = boto.utils.get_instance_metadata()['public-ipv4']
+            return CloudHost.PUBLIC_IP
+        else:
+            attrs = CloudHost.instance_attrs(instance_id)
+            return attrs.ip_address
+
+    @staticmethod
+    def instance_local_ip(instance_id=None):
+        if instance_id is None:
+            if CloudHost.LOCAL_IP is None:
+                if not CloudHost.ENABLED['cloudwatch']:
+                    CloudHost.LOCAL_IP = '127.0.0.1'
+                else:
+                    CloudHost.LOCAL_IP = boto.utils.get_instance_metadata()['local-ipv4']
+            return CloudHost.LOCAL_IP
+        else:
+            attrs = CloudHost.instance_attrs(instance_id)
+            return attrs.private_ip_address
 
     @staticmethod
     def instance_attrs(instance_id=None):

--- a/host/tornado/src/handlers/admin.py
+++ b/host/tornado/src/handlers/admin.py
@@ -129,6 +129,7 @@ class AdminHandler(JBoxHandler):
                 response = {'code': 0, 'data': result}
             except:
                 AdminHandler.log_error("exception while getting stats")
+                AdminHandler._get_logger().exception("exception while getting stats")
                 response = {'code': -1, 'data': 'error getting stats'}
 
         self.write(response)
@@ -148,6 +149,7 @@ class AdminHandler(JBoxHandler):
                 response = {'code': 0, 'data': stats} if stats is not None else {'code': 1, 'data': {}}
             except:
                 AdminHandler.log_error("exception while getting stats")
+                AdminHandler._get_logger().exception("exception while getting stats")
                 response = {'code': -1, 'data': 'error getting stats'}
 
         self.write(response)

--- a/host/tornado/src/jbox_container.py
+++ b/host/tornado/src/jbox_container.py
@@ -156,8 +156,7 @@ class JBoxContainer(LoggerMixin):
     @staticmethod
     def sync_session_status(instance_id):
         JBoxContainer.log_debug("fetching session status from %s", instance_id)
-        addr = '127.0.0.1' if (instance_id == 'localhost') else CloudHost.make_instance_dns_name(instance_id)
-        return JBoxContainer.ASYNC_JOB.sendrecv(JBoxAsyncJob.CMD_SESSION_STATUS, {}, dest=addr)
+        return JBoxContainer.ASYNC_JOB.sendrecv(JBoxAsyncJob.CMD_SESSION_STATUS, {}, dest=instance_id)
 
     @staticmethod
     def launch_by_name(name, email, reuse=True):

--- a/host/tornado/www/ipnbadmin.tpl
+++ b/host/tornado/www/ipnbadmin.tpl
@@ -74,6 +74,11 @@
 	    		parent.JuliaBox.show_ssh_key();
 	    	});
 
+	    	$('#jimg_switch').click(function(event){
+	    		event.preventDefault();
+	    		parent.JuliaBox.switch_julia_image($('#jimg_curr'), $('#jimg_new'));
+	    	});
+
 {% if d["manage_containers"] %}
             $('#showcfg').click(function(event){
 	    		event.preventDefault();
@@ -101,6 +106,7 @@
 	    	});
 {% end %}
 
+            parent.JuliaBox.set_julia_image_type($('#jimg_curr'), $('#jimg_new'), {{d["jimg_type"]}});
 	    	$('#disp_date_init').html((new Date('{{d["created"]}}')).toLocaleString());
 	    	$('#disp_date_start').html((new Date('{{d["started"]}}')).toLocaleString());
 	    	$('#disp_date_allowed_till').html((new Date('{{d["allowed_till"]}}')).toLocaleString());
@@ -126,6 +132,7 @@
 	<tr><td>Allocated Memory:</td><td><span id='disp_mem'></span></td></tr>
 	<tr><td>Allocated CPUs:</td><td>{{d["cpu"]}}</td></tr>
 	<tr><td>SSH Public Key:</td><td><a href="#" id="showsshkey">View</a></td></tr>
+	<tr><td>Julia Image:</td><td><span id='jimg_curr'>precompiled packages</span> (<a href="#" id="jimg_switch"><small>switch to: <span id='jimg_new'>standard</span></small></a>)</td></tr>
 </table>
 
 <h3>JuliaBox version:</h3>

--- a/scripts/install/upload_user_home.py
+++ b/scripts/install/upload_user_home.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 import db
 from db import JBoxDynConfig
@@ -47,6 +48,9 @@ if __name__ == "__main__":
     VolMgr.log_debug("pushing new image file to s3 at: %s", bucket)
     CloudHost.push_file_to_s3(bucket, new_img_file)
 
-    for cluster in ['JuliaBoxTest', 'JuliaBox']:
+    # JuliaBoxTest JuliaBox
+    clusters = sys.argv[1] if (len(sys.argv) > 1) else ['JuliaBoxTest']
+
+    for cluster in clusters:
         VolMgr.log_debug("setting image for cluster: %s", cluster)
         JBoxDynConfig.set_user_home_image(cluster, bucket, new_img_file_name)

--- a/scripts/run/docker_rmall.sh
+++ b/scripts/run/docker_rmall.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+for id in `docker ps -a | cut -d" " -f1 | grep -v CONTAINER`; do echo "removing $id..."; docker kill $id; docker rm $id; done


### PR DESCRIPTION
This updates Julia version to 0.3.4 and also provides a system image with some packages precompiled into it for faster loading.

Currently only `Gadfly` is precompiled (which also pulls in quite a few other useful packages along as dependencies).

When this version gets applied on to juliabox.org, all users would by default be set to use the system image with precompiled packages. Users may switch back to the default system image from the JuliaBox settings tab.

Also present in the PR are a couple of miscellaneous changes:
- bind zmq socket to internal ip only for security
- updates to default package bundle are applied to test cluster by default to prevent inadvertently applying untested stuff to live cluster.