### PR TITLE
Fix accounting table timestamp clash. Add cmake & gfortran

### DIFF
--- a/docker/IJulia/Dockerfile
+++ b/docker/IJulia/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox
-# Version:24
+# Version:25
 
 FROM tanmaykm/jboxjulia:v0.3.5_13
 
@@ -8,11 +8,12 @@ MAINTAINER Tanmay Mohapatra
 # Install additional packages required for Julia packages
 RUN apt-get update \
     && apt-get install -y \
+    cmake \
+    gfortran \
     hdf5-tools \
     python-sympy \
     glpk-utils \
     libnlopt0 \
-    gfortran \
     imagemagick \
     inkscape \
     gettext \

--- a/host/tornado/src/db/accounting_v2.py
+++ b/host/tornado/src/db/accounting_v2.py
@@ -39,7 +39,7 @@ class JBoxAccountingV2(JBoxDB):
         else:
             stop_datetime = stop_time
 
-        stop_time = JBoxAccountingV2.datetime_to_epoch_secs(stop_datetime)
+        stop_time = JBoxAccountingV2.datetime_to_epoch_secs(stop_datetime, allow_microsecs=True)
         stop_date = JBoxAccountingV2.datetime_to_yyyymmdd(stop_datetime)
         data = {
             'stop_date': stop_date,

--- a/host/tornado/src/db/db_base.py
+++ b/host/tornado/src/db/db_base.py
@@ -64,9 +64,12 @@ class JBoxDB(LoggerMixin):
         return dt.year*10000 + dt.month*100 + dt.day
 
     @staticmethod
-    def datetime_to_epoch_secs(dt):
+    def datetime_to_epoch_secs(dt, allow_microsecs=False):
         epoch = datetime.datetime.fromtimestamp(0, pytz.utc)
-        return int((dt - epoch).total_seconds())
+        if allow_microsecs:
+            return (dt - epoch).total_seconds()
+        else:
+            return int((dt - epoch).total_seconds())
 
     @staticmethod
     def epoch_secs_to_datetime(secs):


### PR DESCRIPTION
- Fixed timestamp clash in accounting record insertion. This issue cropped up after the `datetime_to_epoch_secs` was changed to return rounded off values. This adds an option to return milliseconds values, and also retries in case we still get a clash. The table key can be changed along with the next table design iteration to something guaranteed to be unique (session_id + time maybe).
- gfortran and cmake are now part of the base image as they are required to build several packages.