### PR TITLE
fixes for ebs mounts

### DIFF
--- a/host/tornado/src/cloud/aws.py
+++ b/host/tornado/src/cloud/aws.py
@@ -622,12 +622,13 @@ class CloudHost(LoggerMixin):
         mount_point = os.path.join(mount_dir, dev_id)
         actual_mount_point = CloudHost._get_mount_point(dev_id)
         if actual_mount_point == mount_point:
+            CloudHost.log_debug("Device %s already mounted at %s", device, mount_point)
             return
         elif actual_mount_point is None:
-            CloudHost.log_debug("Mounting device " + device + " at " + mount_point)
+            CloudHost.log_debug("Mounting device %s at %s", device, mount_point)
             res = sh.mount(mount_point)  # the mount point must be mentioned in fstab file
             if res.exit_code != 0:
-                raise Exception("Failed to mount device " + device + " at " + mount_point)
+                raise Exception("Failed to mount device %s at %s. Error code: %d", device, mount_point, res.exit_code)
         else:
             raise Exception("Device already mounted at " + actual_mount_point)
         tdiff = int(time.time() - t1)
@@ -884,7 +885,7 @@ class CloudHost(LoggerMixin):
         else:
             CloudHost.log_info("Volume " + vol_id + " already attached to " + att_instance_id + " at " + att_device)
             CloudHost._mount_device(dev_id, mount_dir)
-            return att_device, mount_dir
+            return att_device, os.path.join(mount_dir, dev_id)
 
     @staticmethod
     def snapshot_volume(vol_id=None, dev_id=None, tag=None, description=None, wait_till_complete=True):

--- a/host/tornado/src/cloud/aws.py
+++ b/host/tornado/src/cloud/aws.py
@@ -797,13 +797,12 @@ class CloudHost(LoggerMixin):
         return nt - st
 
     @staticmethod
-    def create_new_volume(snap_id, dev_id, mount_dir, tag=None):
+    def create_new_volume(snap_id, dev_id, mount_dir, tag=None, disk_sz_gb=1):
         CloudHost.log_info("Creating volume with tag " + tag +
                            " from snapshot " + snap_id +
                            " at dev_id " + dev_id +
                            " mount_dir " + mount_dir)
         conn = CloudHost.connect_ec2()
-        disk_sz_gb = 1
         vol = conn.create_volume(disk_sz_gb, CloudHost.zone(),
                                  snapshot=snap_id,
                                  volume_type='gp2')

--- a/host/tornado/src/vol/ebs.py
+++ b/host/tornado/src/vol/ebs.py
@@ -35,7 +35,7 @@ class JBoxEBSVol(JBoxVol):
 
     @classmethod
     def get_disk_allocated_size(cls):
-        return JBoxEBSVol.DISK_LIMIT
+        return JBoxEBSVol.DISK_LIMIT * 1000000000
 
     @staticmethod
     def _id_from_device(dev_path):
@@ -134,10 +134,6 @@ class JBoxEBSVol(JBoxVol):
         pct = (sum(JBoxEBSVol.DISK_USE_STATUS.values()) * 100) / len(JBoxEBSVol.DISK_USE_STATUS)
         return min(100, max(0, pct))
 
-    @classmethod
-    def get_disk_allocated_size(cls):
-        return JBoxEBSVol.DISK_LIMIT
-
     @staticmethod
     def get_disk_for_user(user_email):
         JBoxEBSVol.log_debug("creating EBS volume for %s", user_email)
@@ -167,7 +163,8 @@ class JBoxEBSVol(JBoxVol):
 
             _dev_path, mnt_path, vol_id = CloudHost.create_new_volume(snap_id, disk_id,
                                                                       JBoxEBSVol.FS_LOC,
-                                                                      tag=user_email)
+                                                                      tag=user_email,
+                                                                      disk_sz_gb=JBoxEBSVol.DISK_LIMIT)
             existing_disk = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION,
                                           user_id=user_email,
                                           volume_id=vol_id,

--- a/host/tornado/src/vol/volmgr.py
+++ b/host/tornado/src/vol/volmgr.py
@@ -32,7 +32,7 @@ class VolMgr(LoggerMixin):
         if cloud_cfg['ebs']:
             VolMgr.HAS_EBS = True
             ebs_mnt_location = os.path.expanduser(cloud_cfg['ebs_mnt_location'])
-            JBoxEBSVol.configure(1000000000, ebs_mnt_location, num_disks_max, cloud_cfg['ebs_template'])
+            JBoxEBSVol.configure(1, ebs_mnt_location, num_disks_max, cloud_cfg['ebs_template'])
 
     @staticmethod
     def has_update_for_user_home_image():


### PR DESCRIPTION
If an already attached EBS volume is mounted, the mount point was not reported correctly.
The bug was triggered when launching a container for a user with EBS disks failed for
the first time and the user reattempted the login.