### PR TITLE
REQUEST: add QuantEcon to default installation

### DIFF
--- a/docker/setup_julia.sh
+++ b/docker/setup_julia.sh
@@ -14,4 +14,6 @@ julia -e 'Pkg.add("BayesNets"); Pkg.add("PGFPlots"); Pkg.add("GraphLayout");'
 
 julia -e 'Pkg.add("Stan");'
 
+julia -e 'Pkg.add("QuantEcon");'
+
 julia -e 'Pkg.add("Patchwork"); Pkg.add("Quandl"); Pkg.add("Lazy");'


### PR DESCRIPTION
Per a conversation I had with Viral, this is a request to add [QuantEcon.jl](https://github.com/QuantEcon/QuantEcon.jl) to the list of packages installed by default.