### PR TITLE
Tutorial start: Use Ctrl-Enter to run cell without selecting next

### DIFF
--- a/docker/IJulia/tutorial/00 - Start Tutorial.ipynb
+++ b/docker/IJulia/tutorial/00 - Start Tutorial.ipynb
@@ -36,14 +36,14 @@
      "source": [
       "# Running Julia code\n",
       "\n",
-      "In order to run Julia code, select the cell below and press Shift-Enter. "
+      "In order to run Julia code, select the cell below and press Ctrl-Enter. "
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "1+1       # Try changing the numbers and press Shift-Enter again."
+      "1+1       # Try changing the numbers and press Ctrl-Enter again."
      ],
      "language": "python",
      "metadata": {},
@@ -63,7 +63,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "rand()    # Press Shift-Enter repeatedly to generate new random numbers."
+      "rand()    # Press Ctrl-Enter repeatedly to generate new random numbers."
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Changed Shift-Enter to Ctrl-Enter to run cell, without selecting the next cell.