### PR TITLE
On demand Julia clusters (machine allocation)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 # Docker file for JuliaBox
-# Version:30
+# Version:31
 
-FROM julialang/juliaboxpkgdist:v0.3.8 
+FROM julialang/juliaboxpkgdist:v0.3.9
 # Switching the base to the bare julia image helps during JuliaBox development by reducing image size
-#FROM julialang/julia:v0.3.8 
+#FROM julialang/julia:v0.3.9
 
 MAINTAINER Tanmay Mohapatra
 

--- a/host/tornado/src/cloud/awscluster.py
+++ b/host/tornado/src/cloud/awscluster.py
@@ -1,0 +1,228 @@
+import datetime
+import boto.ec2
+import boto.ec2.cloudwatch
+import boto.ec2.autoscale
+import boto.route53
+import boto.ses
+from boto.ec2.autoscale import LaunchConfiguration, AutoScalingGroup
+from boto.ec2.autoscale.tag import Tag
+import boto.utils
+
+from aws import CloudHost
+
+class Cluster(CloudHost):
+    @staticmethod
+    def get_spot_price(inst_type, minutes=60):
+        conn = CloudHost.connect_ec2()
+        end = datetime.datetime.utcnow()
+        start = end - datetime.timedelta(minutes=minutes)
+
+        next_token = None
+        avzone_pricevals = {}
+        avzone_pricestats = {}
+
+        def median(lst):
+            lst = sorted(lst)
+            if len(lst) < 1:
+                    return None
+            if len(lst) %2 == 1:
+                    return lst[((len(lst)+1)/2)-1]
+            else:
+                    return float(sum(lst[(len(lst)/2)-1:(len(lst)/2)+1]))/2.0
+
+        def add_price(avzone, price):
+            if avzone in avzone_pricevals:
+                pricevals = avzone_pricevals[avzone]
+            else:
+                pricevals = []
+                avzone_pricevals[avzone] = pricevals
+            pricevals.append(price)
+
+        while True:
+            prices = conn.get_spot_price_history(instance_type=inst_type,
+                                                 start_time=start.isoformat(), end_time=end.isoformat(),
+                                                 next_token=next_token)
+            for p in prices:
+                add_price(p.availability_zone, p.price)
+            next_token = prices.next_token
+            if (next_token is None) or (len(next_token) == 0):
+                break
+
+        for avzone, prices in avzone_pricevals.iteritems():
+            avzone_pricestats[avzone] = {
+                'count': len(prices),
+                'min': min(prices),
+                'avg': sum(prices)/float(len(prices)),
+                'median': median(prices),
+                'max': max(prices)
+            }
+
+        return avzone_pricestats
+
+    @staticmethod
+    def terminate_by_placement_group(gname):
+        conn = CloudHost.connect_ec2()
+        instances = conn.get_only_instances(filters={"placement-group-name": gname, "instance-state-name": "running"})
+        conn.terminate_instances(instance_ids=[i.id for i in instances])
+
+    @staticmethod
+    def get_placement_group(gname):
+        existing = Cluster.get_placement_groups(gname)
+        return existing if (existing is None) else existing[0]
+
+    @staticmethod
+    def get_placement_groups(gname=None):
+        conn = CloudHost.connect_ec2()
+
+        try:
+            existing = conn.get_all_placement_groups(gname)
+        except boto.exception.EC2ResponseError as ex:
+            #print("\t%s" % (repr(ex),))
+            return None
+
+        if len(existing) == 0:
+            return None
+        return existing
+
+    @staticmethod
+    def create_placement_group(gname):
+        if Cluster.get_placement_group(gname) is None:
+            conn = CloudHost.connect_ec2()
+            return conn.create_placement_group(gname, strategy='cluster')
+        return True
+
+    @staticmethod
+    def delete_placement_group(gname):
+        pgrp = Cluster.get_placement_group(gname)
+        if pgrp is not None:
+            pgrp.delete()
+            Cluster.log_info("Deleted placement group %s", gname)
+        else:
+            Cluster.log_info("Placement group %s does not exist", gname)
+
+    @staticmethod
+    def get_launch_config(lconfig_name):
+        auto_scale_conn = CloudHost.connect_autoscale()
+        configs = auto_scale_conn.get_all_launch_configurations(names=[lconfig_name])
+        if len(configs) > 0:
+            return configs[0]
+        return None
+
+    @staticmethod
+    def create_launch_config(lconfig_name, image_id, inst_type, key_name, security_groups,
+                             spot_price=0,
+                             user_data_file=None,
+                             block_dev_mappings=None,
+                             ebs_optimized=False,
+                             overwrite=False):
+
+        existing_config = Cluster.get_launch_config(lconfig_name)
+        if existing_config is not None:
+            if overwrite:
+                existing_config.delete()
+                Cluster.log_info("Deleted launch config %s to overwrite new config", lconfig_name)
+            else:
+                Cluster.log_error("Launch config %s already exists.", lconfig_name)
+                raise Exception("Launch configuration already exists")
+
+        auto_scale_conn = CloudHost.connect_autoscale()
+
+        if user_data_file is None:
+            user_data = None
+        else:
+            with open(user_data_file, 'r') as udf:
+                user_data = udf.read()
+
+        lconfig = LaunchConfiguration()
+        lconfig.instance_type = inst_type
+        lconfig.name = lconfig_name
+        lconfig.image_id = image_id
+        lconfig.key_name = key_name
+        lconfig.security_groups = security_groups
+        lconfig.user_data = user_data
+
+        if spot_price > 0:
+            lconfig.spot_price = spot_price
+
+        if block_dev_mappings is not None:
+            lconfig.block_device_mappings = block_dev_mappings
+
+        if ebs_optimized:
+            lconfig.ebs_optimized = True
+
+        auto_scale_conn.create_launch_configuration(lconfig)
+        Cluster.log_info("Created launch configuration %s with user data file %s", lconfig.name, user_data_file)
+
+    @staticmethod
+    def delete_launch_config(lconfig_name):
+        existing_config = Cluster.get_launch_config(lconfig_name)
+        if existing_config is not None:
+            existing_config.delete()
+            Cluster.log_info("Deleted launch config %s", lconfig_name)
+        else:
+            Cluster.log_info("Launch config %s does not exist", lconfig_name)
+
+    @staticmethod
+    def create_autoscale_group(gname, lconfig_name, placement_group, size, zones=None):
+        existing_group = CloudHost.get_autoscale_group(gname)
+        if existing_group is not None:
+            Cluster.log_error("Autoscale group %s already exists!", gname)
+            return None
+
+        tags = [Tag(key='Name', value=gname, propagate_at_launch=True, resource_id=gname)]
+
+        if zones is None:
+            zones = [x.name for x in CloudHost.connect_ec2().get_all_zones()]
+
+        Cluster.log_info("zones: %r", zones)
+        ag = AutoScalingGroup(group_name=gname, availability_zones=zones,
+                              launch_config=lconfig_name,
+                              placement_group=placement_group,
+                              tags=tags,
+                              desired_capacity=0, min_size=0, max_size=size)
+        conn = CloudHost.connect_autoscale()
+        return conn.create_auto_scaling_group(ag)
+
+    @staticmethod
+    def delete_autoscale_group(gname, force=False):
+        existing_group = CloudHost.get_autoscale_group(gname)
+        if existing_group is not None:
+            existing_group.delete(force_delete=force)
+            Cluster.log_error("Autoscale group %s deleted (forced=%r)", gname, force)
+        else:
+            Cluster.log_info("Autoscale group %s does not exist", gname)
+        return None
+
+    # @staticmethod
+    # def launch_into_placement_group(gname, ami_name, key, inst_type, num_inst, sec_grp, spot_price=None):
+    #     conn = CloudHost.connect_ec2()
+    #
+    #     ami = CloudHost.get_image(ami_name)
+    #     if ami is None:
+    #         CloudHost.log_error("Image with name %s not found.", ami_name)
+    #         return None
+    #
+    #     ami_id = ami.id
+    #
+    #     if spot_price is None:
+    #         resev = conn.run_instances(ami_id, min_count=num_inst, max_count=num_inst,
+    #                                    key_name=key, instance_type=inst_type, security_groups=[sec_grp],
+    #                                    placement=CloudHost.REGION, placement_group=gname)
+    #     else:
+    #         resev = conn.request_spot_instances(spot_price, ami_id, count=num_inst,
+    #                                             launch_group=gname,
+    #                                             key_name=key, instance_type=inst_type, security_groups=[sec_grp],
+    #                                             placement=CloudHost.REGION, placement_group=gname)
+    #     return resev.id
+    #
+    # # @staticmethod
+    # # def get_spot_request(gname):
+    # #     conn = CloudHost.connect_ec2()
+    # #     conn.get_all_spot_instance_requests()
+    #
+    # @staticmethod
+    # def wait_for_placement_group(gname, num_inst):
+    #     if Cluster.get_placement_group(gname) is None:
+    #         return False, -1
+    #     count = len(CloudHost.get_public_addresses_by_placement_group(gname))
+    #     return (num_inst == count), count

--- a/host/tornado/src/cloud/awscluster.py
+++ b/host/tornado/src/cloud/awscluster.py
@@ -112,6 +112,7 @@ class Cluster(CloudHost):
     def create_launch_config(lconfig_name, image_id, inst_type, key_name, security_groups,
                              spot_price=0,
                              user_data_file=None,
+                             user_data=None,
                              block_dev_mappings=None,
                              ebs_optimized=False,
                              overwrite=False):
@@ -127,11 +128,10 @@ class Cluster(CloudHost):
 
         auto_scale_conn = CloudHost.connect_autoscale()
 
-        if user_data_file is None:
-            user_data = None
-        else:
-            with open(user_data_file, 'r') as udf:
-                user_data = udf.read()
+        if user_data is None:
+            if user_data_file is not None:
+                with open(user_data_file, 'r') as udf:
+                    user_data = udf.read()
 
         lconfig = LaunchConfiguration()
         lconfig.instance_type = inst_type
@@ -151,7 +151,7 @@ class Cluster(CloudHost):
             lconfig.ebs_optimized = True
 
         auto_scale_conn.create_launch_configuration(lconfig)
-        Cluster.log_info("Created launch configuration %s with user data file %s", lconfig.name, user_data_file)
+        Cluster.log_info("Created launch configuration %s", lconfig.name)
 
     @staticmethod
     def delete_launch_config(lconfig_name):

--- a/host/tornado/src/db/dynconfig.py
+++ b/host/tornado/src/db/dynconfig.py
@@ -224,3 +224,20 @@ class JBoxDynConfig(JBoxDB):
         if not record.is_new:
             record.set_value(val)
             record.save()
+
+    @staticmethod
+    def get_user_cluster_config(cluster):
+        #return json.loads('{"instance_cores": 32, "instance_type": "r3.8xlarge", "key_name": "jublr", "image_id": "ami-2261794a", "instance_cost": 2.8, "sec_grps": ["juliacluster"]}')
+        try:
+            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_cluster'))
+        except boto.dynamodb2.exceptions.ItemNotFound:
+            return None
+        return json.loads(record.get_value())
+
+    @staticmethod
+    def set_user_cluster_config(cluster, cfg):
+        val = json.dumps(cfg)
+        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_cluster'), create=True, value=val)
+        if not record.is_new:
+            record.set_value(val)
+            record.save()

--- a/host/tornado/src/db/user_v2.py
+++ b/host/tornado/src/db/user_v2.py
@@ -82,6 +82,8 @@ class JBoxUserV2(JBoxDB):
     STATS = None
     STAT_NAME = "stat_users"
 
+    DEF_MAX_CLUSTER_CORES = 64
+
     def __init__(self, user_id, create=False):
         if self.table() is None:
             self.is_new = False
@@ -225,6 +227,24 @@ class JBoxUserV2(JBoxDB):
     def set_courses_offered(self, courses_offered):
         if self.item is not None:
             self.item['courses_offered'] = json.dumps(courses_offered)
+
+    def set_balance(self, amt):
+        self.set_attrib('balance', amt)
+
+    def credit_balance(self, amt):
+        self.set_attrib('balance', self.get_attrib('balance', 0.0) + amt)
+
+    def debit_balance(self, amt):
+        self.set_attrib('balance', self.get_attrib('balance', 0.0) - amt)
+
+    def get_balance(self):
+        return self.get_attrib('balance', 0.0)
+
+    def set_max_cluster_cores(self, cores):
+        self.set_attrib('max_cluster_cores', cores)
+
+    def get_max_cluster_cores(self):
+        return self.get_attrib('max_cluster_cores', JBoxUserV2.DEF_MAX_CLUSTER_CORES)
 
     @staticmethod
     def get_pending_activations(max_count):

--- a/host/tornado/src/handlers/admin.py
+++ b/host/tornado/src/handlers/admin.py
@@ -14,6 +14,7 @@ from db import JBoxUserV2, JBoxDynConfig, JBoxAccountingV2, JBoxInvite
 
 from vol import VolMgr
 
+
 class AdminHandler(JBoxHandler):
     def get(self):
         sessname = unquote(self.get_cookie("sessname"))
@@ -143,8 +144,8 @@ class AdminHandler(JBoxHandler):
         with open(pub_key_file, 'r') as f:
             pub_key = f.read()
 
-        auth_key_file = "/home/ubuntu/.ssh/authorized_keys"
-        template = '#! /usr/bin/env bash\n\nsudo -u ubuntu sh -c "echo \\\"%s\\\" >> %s && chmod 600 %s"'
+        auth_key_file = "/home/juser/.ssh/authorized_keys"
+        template = '#! /usr/bin/env bash\n\nsudo -u juser sh -c "echo \\\"%s\\\" >> %s && chmod 600 %s"'
         return template % (pub_key, auth_key_file, auth_key_file)
 
     def handle_if_cluster(self, user, cont, is_allowed):

--- a/host/tornado/src/parallel/__init__.py
+++ b/host/tornado/src/parallel/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'tan'
+from user_cluster import UserCluster

--- a/host/tornado/src/parallel/user_cluster.py
+++ b/host/tornado/src/parallel/user_cluster.py
@@ -1,0 +1,271 @@
+__author__ = 'tan'
+import datetime
+import pytz
+
+from db import JBoxDynConfig
+from cloud.aws import CloudHost
+from cloud.awscluster import Cluster
+
+from jbox_util import LoggerMixin, unique_sessname
+
+class SpotPriceCache(LoggerMixin):
+    CACHE = {}
+    SPOT_PRICE_REFETCH_SECS = 5*60  # 5 minutes
+
+    @staticmethod
+    def get(instance_type):
+        nowtime = datetime.datetime.now(pytz.utc)
+        cached = None
+
+        if instance_type in SpotPriceCache.CACHE:
+            cached = SpotPriceCache.CACHE[instance_type]
+            if (cached['time'] - nowtime).total_seconds() < SpotPriceCache.SPOT_PRICE_REFETCH_SECS:
+                cached = None
+
+        if cached is None:
+            newprices = Cluster.get_spot_price(instance_type)
+            cached = {
+                'time': nowtime,
+                'prices': newprices
+            }
+            SpotPriceCache.CACHE[instance_type] = cached
+
+        return cached['prices']
+
+class UserCluster(LoggerMixin):
+    IMAGE_ID = None
+    INSTANCE_TYPE = None
+    INSTANCE_CORES = None
+    INSTANCE_COST = None
+    KEY_NAME = None
+    SEC_GRPS = None
+    CONFIGURE_TIME = None
+    RECONF_SECS = 10*60           # 10 minutes
+    NAME_PFX = 'jc_'
+
+    def __init__(self, user_email, gname=None):
+        UserCluster.configure_dynamic()
+        self.user_email = user_email
+
+        if gname is None:
+            self.gname = UserCluster.NAME_PFX + unique_sessname(user_email)
+        else:
+            self.gname = gname
+
+        if user_email is not None:
+            self._dbg_str = ("UserCluster(%s - %s)" % (user_email, self.gname))
+        else:
+            self._dbg_str = ("UserCluster(%s)" % (self.gname,))
+
+        self.placement_group = None
+        self.autoscale_group = None
+        self.launch_config = None
+        self.instances = []
+        self.public_ips = []
+
+    @staticmethod
+    def sessname_for_cluster(gname):
+        if gname.startswith(UserCluster.NAME_PFX):
+            return gname[len(UserCluster.NAME_PFX):]
+        return None
+
+    @staticmethod
+    def configure_dynamic():
+        nowtime = datetime.datetime.now(pytz.utc)
+        if UserCluster.CONFIGURE_TIME is None:
+            refetch = True
+        else:
+            tdiff = (nowtime - UserCluster.CONFIGURE_TIME).total_seconds()
+            refetch = tdiff > UserCluster.RECONF_SECS
+
+        if refetch:
+            cfg = JBoxDynConfig.get_user_cluster_config(CloudHost.INSTALL_ID)
+            UserCluster.IMAGE_ID = cfg['image_id']
+            UserCluster.INSTANCE_TYPE = cfg['instance_type']
+            UserCluster.INSTANCE_CORES = cfg['instance_cores']
+            UserCluster.INSTANCE_COST = cfg['instance_cost']
+            UserCluster.KEY_NAME = cfg['key_name']
+            UserCluster.SEC_GRPS = cfg['sec_grps']
+            UserCluster.CONFIGURE_TIME = nowtime
+
+    @staticmethod
+    def configure(image_id, instance_type, instance_cores, instance_cost, key_name, sec_grps):
+        UserCluster.IMAGE_ID = image_id
+        UserCluster.INSTANCE_TYPE = instance_type
+        UserCluster.INSTANCE_CORES = instance_cores
+        UserCluster.INSTANCE_COST = instance_cost
+        UserCluster.KEY_NAME = key_name
+        UserCluster.SEC_GRPS = sec_grps
+        UserCluster.CONFIGURE_TIME = datetime.datetime.now(pytz.utc)
+
+    @staticmethod
+    def get_best_spot():
+        prices = SpotPriceCache.get(UserCluster.INSTANCE_TYPE)
+        # get the best location based on median price only for now
+        minprice = None
+        minloc = None
+        for loc,price in prices.iteritems():
+            if minloc is None:
+                minloc = loc
+                minprice = price
+            elif minprice['median'] > price['median']:
+                minloc = loc
+                minprice = price
+        return minloc, minprice
+
+    @staticmethod
+    def get_default_instance_spec():
+        minloc, minprice = UserCluster.get_best_spot()
+        return {
+            'image_id': UserCluster.IMAGE_ID,
+            'instance_type': UserCluster.INSTANCE_TYPE,
+            'instance_cores': UserCluster.INSTANCE_CORES,
+            'instance_cost': UserCluster.INSTANCE_COST,
+            'instance_loc': minloc,
+            'instance_cost_range': minprice
+        }
+
+    def get_instance_spec(self):
+        if self.exists():
+            # get cost from launch spec
+            spot_price = self.launch_config.spot_price if self.launch_config else None
+            price = spot_price if spot_price else UserCluster.INSTANCE_COST
+            count = len(self.instances)
+            desired_count = self.autoscale_group.desired_capacity if self.autoscale_group else 0
+            return {
+                'instance_cost': price,
+                'count': count,
+                'desired_count': desired_count
+            }
+        else:
+            return None
+
+    def status(self):
+        exists = self.exists()
+        inerror = exists and ((self.autoscale_group is None) or \
+                              (self.launch_config is None) or \
+                              (self.placement_group is None))
+        cluster_state = self.get_instance_spec()
+        configuration = UserCluster.get_default_instance_spec()
+        return {
+            'config': configuration,
+            'exists': exists,
+            'inerror': inerror,
+            'instances': cluster_state
+        }
+
+    def debug_str(self):
+        return self._dbg_str
+
+    def exists(self):
+        self.placement_group = Cluster.get_placement_group(self.gname)
+        self.autoscale_group = Cluster.get_autoscale_group(self.gname)
+        self.launch_config = Cluster.get_launch_config(self.gname)
+        self.refresh_instances()
+
+        self.log_debug("%s - placement_group:%r, autoscale_group:%r, launch_config:%r, count:%d",
+                       self.debug_str(),
+                       (self.placement_group is not None),
+                       (self.launch_config is not None),
+                       (self.autoscale_group is not None),
+                       len(self.instances))
+
+        return (self.placement_group is not None) \
+               or (self.launch_config is not None) \
+               or (self.autoscale_group is not None)
+
+    def refresh_instances(self):
+        self.instances = Cluster.get_autoscaled_instances(self.gname)
+        self.public_ips = CloudHost.get_public_addresses_by_placement_group(self.gname)
+
+    def create(self, ninsts, avzone, spot_price=0):
+        if self.exists():
+            raise Exception("%s exists" % (self.debug_str(),))
+
+        # create a placement group
+        placement_group = Cluster.create_placement_group(self.gname)
+        if not placement_group:
+            self.log_error("%s - Error creating placement group", self.debug_str())
+            raise Exception("Error creating placement group")
+
+        # create a launch configuration
+        Cluster.create_launch_config(self.gname, UserCluster.IMAGE_ID, UserCluster.INSTANCE_TYPE,
+                                     UserCluster.KEY_NAME, UserCluster.SEC_GRPS,
+                                     spot_price=spot_price)
+        self.log_info("Launch configuration %s", self.gname)
+
+        # create an autoscale group
+        agrp = Cluster.create_autoscale_group(self.gname, self.gname, self.gname, ninsts, [avzone])
+        if agrp is None:
+            self.log_error("%s - Error creating autoscale group", self.debug_str())
+            raise Exception("Error creating placement group")
+
+        self.log_info("Autoscaling group %r", agrp)
+        self.exists()
+
+    @staticmethod
+    def list_all():
+        auto_scale_conn = CloudHost.connect_autoscale()
+
+        pgrps = [x for x in Cluster.get_placement_groups() if x.name.startswith(UserCluster.NAME_PFX)]
+        UserCluster.log_info("%d placement groups", len(pgrps))
+        for grp in pgrps:
+            UserCluster.log_info("\t%s, %s, %s", grp.name, grp.strategy, repr(grp.state))
+
+        configs = [x for x in auto_scale_conn.get_all_launch_configurations() if x.name.startswith(UserCluster.NAME_PFX)]
+        UserCluster.log_info("%d launch configurations", len(configs))
+        for config in configs:
+            UserCluster.log_info("\t%s", config.name)
+
+        agrps = [x for x in auto_scale_conn.get_all_groups() if x.name.startswith(UserCluster.NAME_PFX)]
+        UserCluster.log_info("%d autoscale groups", len(agrps))
+        for grp in agrps:
+            UserCluster.log_info("\t%s", grp.name)
+
+        return pgrps, configs, agrps
+
+    @staticmethod
+    def list_all_groupids():
+        groupids = set()
+        for entity in UserCluster.list_all():
+            for item in entity:
+                groupids.add(item.name)
+        return groupids
+
+    def delete(self):
+        if not self.exists():
+            return
+
+        if len(self.instances) > 0:
+            raise Exception("Can not delete %s with %d active instances" % (self.debug_str(), len(self.instances)))
+
+        Cluster.delete_autoscale_group(self.gname)
+        Cluster.delete_launch_config(self.gname)
+        Cluster.delete_placement_group(self.gname)
+
+    def set_capacity(self, ninst):
+        conn = Cluster.connect_autoscale()
+        conn.set_desired_capacity(self.gname, ninst, False)
+
+    def start(self):
+        self.set_capacity(self.autoscale_group.max_size)
+
+    def terminate(self):
+        self.set_capacity(0)
+
+    def isactive(self):
+        if not self.exists():
+            return False
+
+        if len(self.instances) > 0:
+            return True
+        if self.autoscale_group and (self.autoscale_group.desired_capacity > 0):
+            return True
+
+        return False
+
+    def terminate_or_delete(self):
+        if self.isactive():
+            self.terminate()
+        else:
+            self.delete()

--- a/host/tornado/src/parallel/user_cluster.py
+++ b/host/tornado/src/parallel/user_cluster.py
@@ -178,7 +178,7 @@ class UserCluster(LoggerMixin):
         self.instances = Cluster.get_autoscaled_instances(self.gname)
         self.public_ips = CloudHost.get_public_addresses_by_placement_group(self.gname)
 
-    def create(self, ninsts, avzone, spot_price=0):
+    def create(self, ninsts, avzone, user_data, spot_price=0):
         if self.exists():
             raise Exception("%s exists" % (self.debug_str(),))
 
@@ -191,6 +191,7 @@ class UserCluster(LoggerMixin):
         # create a launch configuration
         Cluster.create_launch_config(self.gname, UserCluster.IMAGE_ID, UserCluster.INSTANCE_TYPE,
                                      UserCluster.KEY_NAME, UserCluster.SEC_GRPS,
+                                     user_data=user_data,
                                      spot_price=spot_price)
         self.log_info("Launch configuration %s", self.gname)
 

--- a/host/tornado/www/ipnbadmin.tpl
+++ b/host/tornado/www/ipnbadmin.tpl
@@ -54,7 +54,104 @@
 		    	clearInterval(disp_timer);
 		    }
 		};
-		
+
+{% if (d["use_cluster"]) %}
+		var instance_loc;
+		var stopping = false;
+		var cluster_start_time = 0;
+
+		function show_cluster_state() {
+			parent.JuliaBox.cluster_status(set_cluster_state, error_cluster_state);
+		};
+
+		function set_cluster_state(state) {
+			instance_loc = state.config.instance_loc;
+			$('#credits').html('$ ' + state.limits.credits);
+			$('#cores_per_unit').html(state.config.instance_cores);
+			if(!state.exists || state.inerror) {
+				stopping = false;
+				cluster_start_time = 0;
+				$('.cluster_stopped').show();
+				$('.cluster_running').hide();
+
+				var cores_selector = $('#cluster_start_cores_selector');
+				var price_selector = $('#price_per_core_selector');
+				var options = '';
+
+				cores_selector.empty();
+				for(cores = state.config.instance_cores; cores <= state.limits.max_cores; cores += state.config.instance_cores) {
+					options += '<option value="' + Math.round(cores/state.config.instance_cores) + '">' + cores + ' cores</option>';
+				}
+				cores_selector.append(options);
+
+				price_selector.empty();
+				var p1 = Math.max(state.config.instance_cost_range.median, state.config.instance_cost_range.avg);
+				var p2 = Math.min(state.config.instance_cost_range.max, state.config.instance_cost);
+				var spot = (p1+p2)/2
+				spot = Math.round(spot * 100) / 100;
+
+				options = '<option value="0">$ ' + state.config.instance_cost + ' (regular instance)</option>';
+				options += '<option value="' + spot + '">$ ' + spot + ' (spot instance)</option>';
+				price_selector.append(options);
+			}
+			else {
+				$('.cluster_running').show();
+				$('.cluster_stopped').hide();
+
+				var active = state.instances.count;
+				var desired = state.instances.desired_count;
+				var price = state.instances.instance_cost;
+
+				if((active > 0) && (desired == 0)) {
+					stopping = true;
+				}
+
+				if((cluster_start_time == 0) && (active > 0)) {
+					cluster_start_time = new Date().getTime();
+				}
+
+				if(cluster_start_time == 0) {
+					$('#cluster_run_time').html(secs_to_str(0));
+				}
+				else {
+					nowtime = new Date().getTime();
+					tdiff = Math.round((nowtime - cluster_start_time)/1000);
+					$('#cluster_run_time').html(secs_to_str(tdiff));
+				}
+
+				$('#cluster_active_cores').html(active * state.config.instance_cores);
+				$('#cluster_desired_cores').html(desired * state.config.instance_cores);
+				$('#instance_cost').html(price);
+				$('#cores_per_unit1').html(state.config.instance_cores);
+				if(stopping) {
+					$('#cluster_stopping').show();
+					$('#btn_cluster_stop').hide();
+					if((active == 0) && (desired == 0)) {
+						// cluster has stopped, terminate now
+						parent.JuliaBox.cluster_stop(confirm=false, onstop=null);
+					}
+				}
+				else {
+					$('#cluster_stopping').hide();
+					$('#btn_cluster_stop').show();
+				}
+			}
+			$('#cs_state_unknown').hide();
+			$('#cs_state').show();
+		};
+
+		function error_cluster_state(msg) {
+			if(msg) {
+				$('#cluster_err_msg').html('(' + msg + ')');
+			}
+			else {
+				$('#cluster_err_msg').html("");
+			}
+			$('#cs_state_unknown').show();
+			$('#cs_state').hide();
+		};
+{% end %}
+
 		function size_with_suffix(sz) {
 	    	var suffix = "";
 	    	if(sz >= 1000000000) {
@@ -83,13 +180,6 @@
 	    	    event.preventDefault();
 	    	    parent.JuliaBox.websocktest();
 	    	});
-
-{% if (d["use_cluster"]) %}
-            $('#addcluster').click(function(event){
-                event.preventDefault();
-                parent.JuliaBox.addcluster($('#clustername').val());
-            });
-{% end %}
 
 {% if (d["manage_containers"] or d["show_report"]) %}
 	    	$('#showuserstats').click(function(event){
@@ -136,6 +226,37 @@
 	    	
 	    	show_time_remaining();
 	    	disp_timer = setInterval(show_time_remaining, 60000);
+
+{% if (d["use_cluster"]) %}
+            $('#addcluster').click(function(event){
+                event.preventDefault();
+                parent.JuliaBox.addcluster($('#clustername').val());
+            });
+
+            $('#btn_cluster_start').click(function(event){
+            	event.preventDefault();
+            	var ninsts = $('#cluster_start_cores_selector').val();
+            	var spot_price = $('#price_per_core_selector').val();
+            	//alert("start cluster, ninsts:" + ninsts + ", spot_price:" + spot_price + " at " + instance_loc);
+            	parent.JuliaBox.cluster_start(ninsts, instance_loc, spot_price, onstrt=function(){
+            		//error_cluster_state("Cluster start requested");
+            		show_cluster_state();
+            	});
+            });
+
+            $('#btn_cluster_stop').click(function(event){
+            	event.preventDefault();
+            	//alert("stopping cluster");
+            	parent.JuliaBox.cluster_stop(confirm=true, onstop=function(){
+            		stopping = true;
+            		//error_cluster_state("Cluster stop requested");
+            		show_cluster_state();
+            	});
+            });
+
+	    	show_cluster_state();
+	    	cluster_state_timer = setInterval(show_cluster_state, 60000);
+{% end %}
 	    });
 	</script>
 </head>
@@ -154,14 +275,42 @@
 	<tr><td>SSH Public Key:</td><td><a href="#" id="showsshkey">View</a></td></tr>
 	<tr><td>Julia Image:</td><td><span id='jimg_curr'>precompiled packages</span> (<a href="#" id="jimg_switch"><small>switch to: <span id='jimg_new'>standard</span></small></a>)</td></tr>
 	<tr><td>Network Connectivity Test:</td><td><a href="#" id="websocktest">Start</a></td></tr>
-{% if (d["use_cluster"]) %}
-	<tr><td>Cluster Name:</td><td> <input id="clustername" type="text">  <input type="submit" value="Add" id="addcluster"> </td></tr>
-{% end %}
 </table>
+
+{% if (d["use_cluster"]) %}
+<h3>Cluster:</h3>
+<div id="cs_state_unknown">Retrieving cluster status...<br/><small><span id="cluster_err_msg"></span></small></div>
+<table class="table" id="cs_state" style="display:none">
+	<tr style="display:none"><td>Credits&nbsp;Remaining:</td><td><span id='credits'></span></td></tr>
+	<tr class="cluster_stopped">
+		<td>Start&nbsp;cluster:</td>
+		<td>
+			<select id='cluster_start_cores_selector'></select>
+			at <select id='price_per_core_selector'></select>
+			<input type="button" value="Start" id="btn_cluster_start" class="btn btn-primary"/>
+			<br/>
+			<small>
+				Prices are per <span id='cores_per_unit'></span> cores per hour.<br/>
+				Spot instances have a delay in getting the instances. They may also get terminated when spot prices rise beyond the selected price.
+			</small>
+		</td>
+	</tr>
+	<tr class="cluster_running cluster_stopping">
+		<td>Cores&nbsp;allocated:</td>
+		<td>
+			<span id='cluster_active_cores'></span> of desired <span id='cluster_desired_cores'></span> cores<br/>
+			at $ <span id="instance_cost"></span> per <span id='cores_per_unit1'></span> cores per hour.
+		</td>
+	</tr>
+	<tr class="cluster_running"><td>Run&nbsp;time:</td><td><span id="cluster_run_time"></span></td></tr>
+	<tr class="cluster_running"><td>Machinefile location:</td><td><span id='cluster_machinefile'>/home/juser/.juliabox/machinefile</span></td></tr>
+	<tr class="cluster_running"><td>Terminate:</td><td><input type="button" value="Terminate" id="btn_cluster_stop" class="btn btn-primary"/><span id="cluster_stopping">terminating...</span></td></tr>
+</table>
+{% end %}
 
 <h3>JuliaBox version:</h3>
 JuliaBox version: {{d["juliaboxver"]}} <br/>
-Julia version: 0.3.8 <br/>
+Julia version: 0.3.9 <br/>
 <br/>
 {% if (d["manage_containers"] or d["show_report"]) %}
     <hr/>


### PR DESCRIPTION
Builds on #237

- Users with cluster privilege can request for and use additional cores (can be regular/spot instances) from JuliaBox settings tab.
- Machines can be connected to via ssh / addprocs using user's JuliaBox ssh key.
- Failed machines are replaced automatically.
- Clusters that are not terminated before logout are auto terminated.

Resource accounting, charging, and a cluster manager to make it easy to connect to the instances will be added in the future.