### PR TITLE
Make Julia nightly available. Provide cluster private IPs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox
-# Version:31
+# Version:32
 
 FROM julialang/juliaboxpkgdist:v0.3.9
 # Switching the base to the bare julia image helps during JuliaBox development by reducing image size
@@ -15,6 +15,11 @@ RUN git clone https://github.com/tanmaykm/shellinabox_fork.git; cd shellinabox_f
 RUN groupadd juser \
     && useradd -m -d /home/juser -s /bin/bash -g juser -G staff juser \
     && echo "export HOME=/home/juser" >> /home/juser/.bashrc
+
+# add Julia nightly build
+RUN mkdir -p /opt/julia_0.4.0 && \
+    curl -s -L https://status.julialang.org/download/linux-x86_64 | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
+RUN ln -fs /opt/julia_0.4.0 /opt/julia_nightly
 
 USER juser
 ENV HOME /home/juser

--- a/docker/IJulia/tornado/src/fmanage.py
+++ b/docker/IJulia/tornado/src/fmanage.py
@@ -110,6 +110,17 @@ class SSHKeyHandler(tornado.web.RequestHandler):
             self.write(response)
 
 
+class PkgInfoHandler(tornado.web.RequestHandler):
+    def get(self):
+        ver = self.get_argument('ver')
+        with open(os.path.expanduser('~/.juliabox/' + ver + '_packages.txt'), "r") as f:
+            response = {
+                'code': 0,
+                'data': f.read()
+            }
+            self.write(response)
+
+
 class SyncHandler(tornado.web.RequestHandler):
     LOC = '~/'
     # LOC = '/tmp/x'
@@ -286,6 +297,7 @@ if __name__ == "__main__":
         (r"/ping", PingHandler),
         (r"/sync", SyncHandler),
         (r"/sshkey", SSHKeyHandler),
+        (r"/pkginfo", PkgInfoHandler),
         (r"/", BrowseHandler)
     ])
     application.listen(cfg['port'])

--- a/docker/mk_user_home.sh
+++ b/docker/mk_user_home.sh
@@ -53,6 +53,10 @@ do
     echo "c.NotebookApp.allow_origin = \"*\"" | ${SUDO_JUSER} tee --append ${JUSER_HOME}/.ipython/profile_${prof}/ipython_notebook_config.py
     ${SUDO_JUSER} cp ${DIR}/IJulia/custom.css ${JUSER_HOME}/.ipython/profile_${prof}/static/custom/custom.css
     ${SUDO_JUSER} cp ${DIR}/IJulia/custom.js ${JUSER_HOME}/.ipython/profile_${prof}/static/custom/custom.js
+
+    # Do not add kernel cmd to config.py files, just having it in kernel.json seems to work.
+    # This avoids the requirement of having to recompile IJulia after switching kernel.
+    ${SUDO_JUSER} sed -i "s/^c.KernelManager.kernel_cmd =/# c.KernelManager.kernel_cmd =/" ${JUSER_HOME}/.ipython/profile_${prof}/ipython_config.py
 done
 
 ${SUDO_JUSER} cp -R ${DIR}/IJulia/tornado ${JUSER_HOME}/.juliabox/tornado

--- a/docker/setup_julia.sh
+++ b/docker/setup_julia.sh
@@ -32,7 +32,7 @@ julia -e "Pkg.checkout(\"Interact\")"
 
 echo ""
 echo "Creating Julia stable package list..."
-julia -e 'println("Location: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/stable_packages.txt
+julia -e 'println("JULIA_HOME: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/stable_packages.txt
 #echo ""
 #echo "Running package tests..."
 #julia -e "Pkg.test()" > /home/juser/.juliabox/packages_test_result.txt
@@ -59,4 +59,4 @@ done
 
 echo ""
 echo "Creating Julia nightly package list..."
-/opt/julia_nightly/bin/julia -e 'println("Location: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/nightly_packages.txt
+/opt/julia_nightly/bin/julia -e 'println("JULIA_HOME: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/nightly_packages.txt

--- a/docker/setup_julia.sh
+++ b/docker/setup_julia.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Install packages for Julia stable
 DEFAULT_PACKAGES="IJulia PyPlot SIUnits Gadfly DataStructures HDF5 MAT \
 Iterators NumericExtensions SymPy Interact Roots \
 DataFrames RDatasets Distributions SVM Clustering GLM \
@@ -12,7 +13,7 @@ Stan Patchwork Quandl Lazy QuantEcon MixedModels Escher"
 for pkg in ${DEFAULT_PACKAGES}
 do
     echo ""
-    echo "Adding default package $pkg"
+    echo "Adding default package $pkg to Julia stable"
     julia -e "Pkg.add(\"$pkg\")"
 done
 
@@ -23,15 +24,39 @@ https://github.com/tanmaykm/JuliaWebAPI.jl.git"
 for pkg in ${INTERNAL_PACKAGES}
 do
     echo ""
-    echo "Adding internal package $pkg"
+    echo "Adding internal package $pkg to Julia stable"
     julia -e "Pkg.clone(\"$pkg\")"
 done
 
 julia -e "Pkg.checkout(\"Interact\")"
 
 echo ""
-echo "Creating package list..."
-julia -e "Pkg.status()" > /home/juser/.juliabox/packages.txt
+echo "Creating Julia stable package list..."
+julia -e 'println("Location: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/stable_packages.txt
 #echo ""
 #echo "Running package tests..."
 #julia -e "Pkg.test()" > /home/juser/.juliabox/packages_test_result.txt
+
+
+# Install packages for Julia nightly
+JULIA_NIGHTLY_DEFAULT_PACKAGES="IJulia"
+
+for pkg in ${JULIA_NIGHTLY_DEFAULT_PACKAGES}
+do
+    echo ""
+    echo "Adding default package $pkg to Julia nightly"
+    /opt/julia_nightly/bin/julia -e "Pkg.add(\"$pkg\")"
+done
+
+JULIA_NIGHTLY_INTERNAL_PACKAGES="https://github.com/tanmaykm/JuliaBoxUtils.jl.git"
+
+for pkg in ${JULIA_NIGHTLY_INTERNAL_PACKAGES}
+do
+    echo ""
+    echo "Adding internal package $pkg to Julia nightly"
+    /opt/julia_nightly/bin/julia -e "Pkg.clone(\"$pkg\")"
+done
+
+echo ""
+echo "Creating Julia nightly package list..."
+/opt/julia_nightly/bin/julia -e 'println("Location: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/nightly_packages.txt

--- a/host/nginx/www/assets/js/juliabox.js
+++ b/host/nginx/www/assets/js/juliabox.js
@@ -56,6 +56,17 @@ var JuliaBox = (function($, _, undefined){
 	    	self.comm('/hostupload/sshkey', 'GET', null, s, f);
 	    },
 
+	    show_packages: function(ver) {
+	    	s = function(pkginfo){
+	    		bootbox.dialog({
+	    	            message: '<pre>' + pkginfo.data + '<pre>',
+	    	            title: "Julia " + ver
+	    	        }).find("div.modal-dialog").addClass("bootbox90");
+	    	};
+	    	f = function() { bootbox.alert("Oops. Unexpected error while retrieving packages list.<br/><br/>Please try again later."); };
+	    	self.comm('/hostupload/pkginfo', 'GET', {'ver': ver}, s, f);
+	    },
+
 	    switch_julia_image: function(disp_curr, disp_switch) {
 	    	s = function(img){
 	    	    if(img.code == 0) {

--- a/host/tornado/src/juliabox/cloud/aws.py
+++ b/host/tornado/src/juliabox/cloud/aws.py
@@ -378,28 +378,34 @@ class CloudHost(LoggerMixin):
         return True
 
     @staticmethod
-    def get_public_addresses_by_tag(tag, value):
+    def get_public_hostnames_by_tag(tag, value):
         conn = CloudHost.connect_ec2()
         instances = conn.get_only_instances(filters={"tag:"+tag: value, "instance-state-name": "running"})
         return [i.public_dns_name for i in instances]
         
     @staticmethod
-    def get_private_addresses_by_tag(tag, value):
+    def get_private_hostnames_by_tag(tag, value):
         conn = CloudHost.connect_ec2()
         instances = conn.get_only_instances(filters={"tag:"+tag: value, "instance-state-name": "running"})
         return [i.private_dns_name for i in instances]
 
     @staticmethod
-    def get_public_addresses_by_placement_group(gname):
+    def get_public_hostnames_by_placement_group(gname):
         conn = CloudHost.connect_ec2()
         instances = conn.get_only_instances(filters={"placement-group-name": gname, "instance-state-name": "running"})
         return [i.public_dns_name for i in instances]
         
     @staticmethod
-    def get_private_addresses_by_placement_group(gname):
+    def get_private_hostnames_by_placement_group(gname):
         conn = CloudHost.connect_ec2()
         instances = conn.get_only_instances(filters={"placement-group-name": gname, "instance-state-name": "running"})
         return [i.private_dns_name for i in instances]
+
+    @staticmethod
+    def get_private_ips_by_placement_group(gname):
+        conn = CloudHost.connect_ec2()
+        instances = conn.get_only_instances(filters={"placement-group-name": gname, "instance-state-name": "running"})
+        return [i.private_ip_address for i in instances]
 
     @staticmethod
     def get_image(image_name):

--- a/host/tornado/src/juliabox/plugins/parallel/parallel_handler.py
+++ b/host/tornado/src/juliabox/plugins/parallel/parallel_handler.py
@@ -122,14 +122,14 @@ class ParallelHandler(JBoxHandlerPlugin):
 
         self.write(response)
 
-    def write_machinefile(self, cont, uc):
-        cluster_hosts = set(uc.public_ips)
+    def _write_machinefile(self, cont, filename, machines):
+        cluster_hosts = set(machines)
         if len(cluster_hosts) == 0:
             return
 
         # write out the machinefile on the docker's filesystem
         vol = VolMgr.get_disk_from_container(cont.dockid)
-        machinefile = os.path.join(vol.disk_path, ".juliabox", "machinefile")
+        machinefile = os.path.join(vol.disk_path, ".juliabox", filename)
 
         existing_hosts = set()
         try:
@@ -145,6 +145,10 @@ class ParallelHandler(JBoxHandlerPlugin):
         with open(machinefile, 'w') as f:
             for host in cluster_hosts:
                 f.write(host+'\n')
+
+    def write_machinefile(self, cont, uc):
+        self._write_machinefile(cont, "machinefile", uc.public_ips)
+        self._write_machinefile(cont, "machinefile.private", uc.private_ips)
 
     @staticmethod
     def create_user_script(cont):

--- a/host/tornado/src/juliabox/plugins/parallel/user_cluster.py
+++ b/host/tornado/src/juliabox/plugins/parallel/user_cluster.py
@@ -63,6 +63,7 @@ class UserCluster(LoggerMixin):
         self.launch_config = None
         self.instances = []
         self.public_ips = []
+        self.private_ips = []
 
     @staticmethod
     def sessname_for_cluster(gname):
@@ -177,7 +178,8 @@ class UserCluster(LoggerMixin):
 
     def refresh_instances(self):
         self.instances = Cluster.get_autoscaled_instances(self.gname)
-        self.public_ips = CloudHost.get_public_addresses_by_placement_group(self.gname)
+        self.public_ips = CloudHost.get_public_hostnames_by_placement_group(self.gname)
+        self.private_ips = CloudHost.get_private_ips_by_placement_group(self.gname)
 
     def create(self, ninsts, avzone, user_data, spot_price=0):
         if self.exists():

--- a/host/tornado/www/ipnbadmin.tpl
+++ b/host/tornado/www/ipnbadmin.tpl
@@ -74,6 +74,16 @@
 	    		parent.JuliaBox.show_ssh_key();
 	    	});
 
+	    	$('#showpackagesstable').click(function(event){
+	    		event.preventDefault();
+	    		parent.JuliaBox.show_packages('stable');
+	    	});
+
+	    	$('#showpackagesnightly').click(function(event){
+	    		event.preventDefault();
+	    		parent.JuliaBox.show_packages('nightly');
+	    	});
+
 	    	$('#jimg_switch').click(function(event){
 	    		event.preventDefault();
 	    		parent.JuliaBox.switch_julia_image($('#jimg_curr'), $('#jimg_new'));
@@ -151,7 +161,7 @@
 
 <h3>JuliaBox version:</h3>
 JuliaBox version: {{d["juliaboxver"]}} <br/>
-Julia version: 0.3.9 <br/>
+Julia versions and packages: <a href="#" id="showpackagesstable">stable</a> | <a href="#" id="showpackagesnightly">nightly</a><br/>
 <br/>
 
 {% include "../../../www/admin_modules.tpl" %}


### PR DESCRIPTION
Provide Julia nightly:
- Stable version remains as primary version
- Julia nightly with minimal packages also available
- settings console shows Julia versioninfo and package list

Update parallel cluster plugin to create a separate machine file with private IP addresses of the launched instances. Using private IPs may speed up `addprocs`.