### PR TITLE
Persistent packages. Default packages in LOAD_PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 # Docker file for JuliaBox
-# Version:32
+# Version:33
 
-FROM julialang/juliaboxpkgdist:v0.3.9
+FROM julialang/juliaboxpkgdist:v0.3.10
 # Switching the base to the bare julia image helps during JuliaBox development by reducing image size
-#FROM julialang/julia:v0.3.9
+#FROM julialang/julia:v0.3.10
 
 MAINTAINER Tanmay Mohapatra
 
@@ -20,6 +20,12 @@ RUN groupadd juser \
 RUN mkdir -p /opt/julia_0.4.0 && \
     curl -s -L https://status.julialang.org/download/linux-x86_64 | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
 RUN ln -fs /opt/julia_0.4.0 /opt/julia_nightly
+
+# JuliaBox package bundle shall be mounted at /opt/julia_packages.
+# They are added to LOAD_PATH through respective juliarc.jl scripts.
+RUN mkdir /opt/julia_packages
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.4/")' >> /opt/julia_0.4.0/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/")' >> /opt/julia_0.3.10/etc/julia/juliarc.jl
 
 USER juser
 ENV HOME /home/juser

--- a/docker/IJulia/tornado/src/fmanage.py
+++ b/docker/IJulia/tornado/src/fmanage.py
@@ -113,7 +113,7 @@ class SSHKeyHandler(tornado.web.RequestHandler):
 class PkgInfoHandler(tornado.web.RequestHandler):
     def get(self):
         ver = self.get_argument('ver')
-        with open(os.path.expanduser('~/.juliabox/' + ver + '_packages.txt'), "r") as f:
+        with open('/opt/julia_packages/' + ver + '_packages.txt', "r") as f:
             response = {
                 'code': 0,
                 'data': f.read()

--- a/docker/mk_user_home.sh
+++ b/docker/mk_user_home.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 JUSER_HOME=/tmp/juser
+PKG_DIR=/tmp/jpkg
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #SUDO_JUSER="sudo -u#1000 -g#1000"
 SUDO_JUSER=""
@@ -11,9 +12,12 @@ function error_exit {
 }
 
 sudo rm -rf ${JUSER_HOME}
+sudo rm -rf ${PKG_DIR}
 mkdir -p ${JUSER_HOME}
+mkdir -p ${PKG_DIR}
 mkdir -p ${JUSER_HOME}/.juliabox
-mkdir -p ${JUSER_HOME}/.juliabox/jimg
+mkdir -p ${PKG_DIR}/jimg/stable
+mkdir -p ${PKG_DIR}/jimg/nightly
 
 cp ${DIR}/setup_julia.sh ${JUSER_HOME}
 cp ${DIR}/build_sysimg.jl ${JUSER_HOME}
@@ -21,30 +25,12 @@ cp ${DIR}/jimg.jl ${JUSER_HOME}
 cp ${DIR}/mkjimg.jl ${JUSER_HOME}
 
 sudo chown -R 1000:1000 ${JUSER_HOME}
-sudo docker run -i -v ${JUSER_HOME}:/home/juser --entrypoint="/home/juser/setup_julia.sh" juliabox/juliabox:latest || error_exit "Could not run juliabox image"
-sudo docker run -i -v ${JUSER_HOME}:/home/juser --user=root --workdir=/home/juser --entrypoint="julia" juliabox/juliabox:latest mkjimg.jl || error_exit "Could not run juliabox image"
+sudo chown -R 1000:1000 ${PKG_DIR}
+sudo docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --entrypoint="/home/juser/setup_julia.sh" juliabox/juliabox:latest || error_exit "Could not run juliabox image"
+sudo docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --user=root --workdir=/home/juser --entrypoint="julia" juliabox/juliabox:latest mkjimg.jl || error_exit "Could not run juliabox image"
 sudo chown -R 1000:1000 ${JUSER_HOME}
+sudo chown -R 1000:1000 ${PKG_DIR}
 ${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh ${JUSER_HOME}/build_sysimg.jl ${JUSER_HOME}/jimg.jl ${JUSER_HOME}/mkjimg.jl
-
-## create julia kernels
-#${SUDO_JUSER} mkdir -p ${JUSER_HOME}/.ipython/kernels/julia\ 0.3
-#${SUDO_JUSER} cat > ${JUSER_HOME}/.ipython/kernels/julia\ 0.3/kernel.json <<EOF
-#{
-#        "argv": ["/usr/bin/julia", "-F", "/home/juser/.julia/v0.3/IJulia/src/kernel.jl", "{connection_file}"],
-#        "display_name": "Julia 0.3.6",
-#        "language": "julia"
-#}
-#EOF
-
-#${SUDO_JUSER} mkdir -p ${JUSER_HOME}/.ipython/kernels/jboxjulia
-#${SUDO_JUSER} cat > ${JUSER_HOME}/.ipython/kernels/jboxjulia/kernel.json <<EOF
-#{
-#        "argv": ["/usr/bin/julia", "-J", "/home/juser/.juliabox/jimg/sys.ji", "-F", "/home/juser/.julia/v0.3/IJulia/src/kernel.jl", "{connection_file}"],
-#        "codemirror_mode": "julia",
-#        "display_name": "Julia(JuliaBox)",
-#        "language": "julia"
-#}
-#EOF
 
 for prof in "julia" "jboxjulia"
 do
@@ -63,9 +49,14 @@ ${SUDO_JUSER} cp -R ${DIR}/IJulia/tornado ${JUSER_HOME}/.juliabox/tornado
 ${SUDO_JUSER} cp ${DIR}/IJulia/supervisord.conf ${JUSER_HOME}/.juliabox/supervisord.conf
 ${SUDO_JUSER} cp -R ${DIR}/IJulia/tutorial ${JUSER_HOME}/.juliabox/tutorial
 
+sudo rm ~/julia_packages.tar.gz
+sudo tar -czvf ~/julia_packages.tar.gz -C ${PKG_DIR} .
+
 sudo rm ~/user_home.tar.gz
 sudo tar -czvf ~/user_home.tar.gz -C ${JUSER_HOME} .
+
 sudo rm -rf ${JUSER_HOME}
+sudo rm -rf ${PKG_DIR}
 for id in `docker ps -a | grep Exited | cut -d" " -f1 | grep -v CONTAINER`
 do
     echo "removing $id..."

--- a/docker/mkjimg.jl
+++ b/docker/mkjimg.jl
@@ -1,7 +1,7 @@
 require("/home/juser/build_sysimg.jl")
 
 println("Building JuliaBox Julia system image...")
-build_sysimg("/home/juser/.juliabox/jimg/sys", "native", "/home/juser/jimg.jl", force=true)
+build_sysimg("/opt/julia_packages/jimg/stable/sys", "native", "/home/juser/jimg.jl", force=true)
 
 # create the JuliaBox Julia profile
 # TODO: this should probably be merged with IJulia deps
@@ -11,7 +11,7 @@ eprintln("Creating julia profile in IPython...")
 include(joinpath(Pkg.dir("IJulia"), "deps", "ipython.jl"))
 const ipython, ipyvers = find_ipython()
 const profile_name = "jboxjulia"
-const custom_args = ["-J", "/home/juser/.juliabox/jimg/sys.ji"]
+const custom_args = ["-J", "/opt/julia_packages/jimg/stable/sys.ji"]
 
 run(`$ipython profile create $profile_name`)
 

--- a/docker/setup_julia.sh
+++ b/docker/setup_julia.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+julia -e 'Pkg.init()'
+
 # Install packages for Julia stable
 DEFAULT_PACKAGES="IJulia PyPlot SIUnits Gadfly DataStructures HDF5 MAT \
 Iterators NumericExtensions SymPy Interact Roots \
@@ -32,11 +34,13 @@ julia -e "Pkg.checkout(\"Interact\")"
 
 echo ""
 echo "Creating Julia stable package list..."
-julia -e 'println("JULIA_HOME: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/stable_packages.txt
+julia -e 'println("JULIA_HOME: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /opt/julia_packages/stable_packages.txt
 #echo ""
 #echo "Running package tests..."
-#julia -e "Pkg.test()" > /home/juser/.juliabox/packages_test_result.txt
+#julia -e "Pkg.test()" > /opt/julia_packages/packages_test_result.txt
 
+
+/opt/julia_nightly/bin/julia -e 'Pkg.init()'
 
 # Install packages for Julia nightly
 JULIA_NIGHTLY_DEFAULT_PACKAGES="IJulia"
@@ -59,4 +63,4 @@ done
 
 echo ""
 echo "Creating Julia nightly package list..."
-/opt/julia_nightly/bin/julia -e 'println("JULIA_HOME: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /home/juser/.juliabox/nightly_packages.txt
+/opt/julia_nightly/bin/julia -e 'println("JULIA_HOME: $JULIA_HOME\n"); versioninfo(); println(""); Pkg.status()' > /opt/julia_packages/nightly_packages.txt

--- a/host/tornado/conf/tornado.conf.tpl
+++ b/host/tornado/conf/tornado.conf.tpl
@@ -32,7 +32,7 @@
     # Max 1024 cpu slices. default maximum allowed is 1/8th of total cpu slices. multiplier can be applied from user profile.
     "cpu_limit" : 128,
     # Max size of user home. Default 500MB. User home is backed up within 10 minutes of the container stopping.
-    "disk_limit" : 750000000,
+    "disk_limit" : 500000000,
     
     # Seconds to wait before clearing an inactive session, for example, when the user closes the browser window (protected_sessions are not affected)
     "inactivity_timeout" : 300,

--- a/host/tornado/conf/tornado.conf.tpl
+++ b/host/tornado/conf/tornado.conf.tpl
@@ -101,12 +101,15 @@ Welcome to JuliaBox. We hope you will like it and also share with your friends.
 
     "env_type" : "prod",
     "backup_location" : "~/juliabox_backup",
+    "pkg_location": "~/julia_packages",
     "mnt_location" : "/mnt/jbox/mnt",
     "user_home_image" : "~/user_home.tar.gz",
+    "pkg_image": "~/julia_packages.tar.gz",
 
     "plugins": [
         "juliabox.plugins.vol_loopback",
         "juliabox.plugins.vol_ebs",
+        "juliabox.plugins.vol_defpkg",
         "juliabox.plugins.course_homework",
         "juliabox.plugins.parallel",
         ""

--- a/host/tornado/src/juliabox/db/dynconfig.py
+++ b/host/tornado/src/juliabox/db/dynconfig.py
@@ -150,15 +150,18 @@ class JBoxDynConfig(JBoxDB):
         try:
             record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_home_image'))
         except boto.dynamodb2.exceptions.ItemNotFound:
-            return None, None
+            return None, None, None
         img = json.loads(record.get_value())
-        return img['bucket'], img['filename']
+        pkg_file = img['pkg_file'] if 'pkg_file' in img else None
+        home_file = img['home_file'] if 'home_file' in img else None
+        return img['bucket'], pkg_file, home_file
 
     @staticmethod
-    def set_user_home_image(cluster, bucket, filename):
+    def set_user_home_image(cluster, bucket, pkg_file, home_file):
         img = {
             'bucket': bucket,
-            'filename': filename
+            'pkg_file': pkg_file,
+            'home_file': home_file
         }
         img = json.dumps(img)
         record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_home_image'), create=True, value=img)

--- a/host/tornado/src/juliabox/plugins/parallel/parallel_handler.py
+++ b/host/tornado/src/juliabox/plugins/parallel/parallel_handler.py
@@ -5,7 +5,7 @@ from juliabox.jbox_util import unquote
 from juliabox.handlers import JBoxHandlerPlugin, JBoxUIModulePlugin
 from juliabox.jbox_container import JBoxContainer
 from juliabox.db import JBoxUserV2
-from juliabox.vol import VolMgr
+from juliabox.vol import VolMgr, JBoxVol
 from user_cluster import UserCluster
 
 
@@ -128,7 +128,7 @@ class ParallelHandler(JBoxHandlerPlugin):
             return
 
         # write out the machinefile on the docker's filesystem
-        vol = VolMgr.get_disk_from_container(cont.dockid)
+        vol = VolMgr.get_disk_from_container(cont.dockid, JBoxVol.PLUGIN_USERHOME)
         machinefile = os.path.join(vol.disk_path, ".juliabox", filename)
 
         existing_hosts = set()
@@ -156,7 +156,7 @@ class ParallelHandler(JBoxHandlerPlugin):
 
     @staticmethod
     def create_user_script(cont):
-        vol = VolMgr.get_disk_from_container(cont.dockid)
+        vol = VolMgr.get_disk_from_container(cont.dockid, JBoxVol.PLUGIN_USERHOME)
 
         pub_key_file = os.path.join(vol.disk_path, ".ssh", "id_rsa.pub")
         with open(pub_key_file, 'r') as f:

--- a/host/tornado/src/juliabox/plugins/vol_defpkg/__init__.py
+++ b/host/tornado/src/juliabox/plugins/vol_defpkg/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'tan'
+from defpkg import JBoxDefaultPackagesVol

--- a/host/tornado/src/juliabox/plugins/vol_defpkg/defpkg.py
+++ b/host/tornado/src/juliabox/plugins/vol_defpkg/defpkg.py
@@ -1,0 +1,137 @@
+import os
+import threading
+import tarfile
+
+from juliabox.jbox_util import ensure_delete, make_sure_path_exists, JBoxCfg
+from juliabox.vol import JBoxVol
+
+
+class JBoxDefaultPackagesVol(JBoxVol):
+    provides = [JBoxVol.PLUGIN_PKGBUNDLE]
+
+    FS_LOC = None
+    LOCK = None
+    CURRENT_BUNDLE = None
+    BUNDLES_IN_USE = set()
+
+    @staticmethod
+    def configure():
+        pkg_location = os.path.expanduser(JBoxCfg.get('pkg_location'))
+        make_sure_path_exists(pkg_location)
+
+        JBoxDefaultPackagesVol.FS_LOC = pkg_location
+        JBoxDefaultPackagesVol.LOCK = threading.Lock()
+        JBoxDefaultPackagesVol.refresh_disk_use_status()
+
+    @staticmethod
+    def _get_package_mounts_used(cid):
+        used = []
+        props = JBoxDefaultPackagesVol.dckr().inspect_container(cid)
+        try:
+            vols = props['Volumes']
+            for _cpath, hpath in vols.iteritems():
+                if hpath.startswith(JBoxDefaultPackagesVol.FS_LOC):
+                    used.append(hpath.split('/')[-1])
+        except:
+            JBoxDefaultPackagesVol.log_error("error finding package mount points used in " + cid)
+            return []
+        return used
+
+    @staticmethod
+    def refresh_disk_use_status(container_id_list=None):
+        JBoxDefaultPackagesVol.LOCK.acquire()
+        bundles = set()
+        try:
+            if container_id_list is None:
+                container_id_list = [cdesc['Id'] for cdesc in JBoxDefaultPackagesVol.dckr().containers(all=True)]
+
+            for cid in container_id_list:
+                mount_points = JBoxDefaultPackagesVol._get_package_mounts_used(cid)
+                bundles.update(mount_points)
+
+            JBoxDefaultPackagesVol.BUNDLES_IN_USE = bundles
+            JBoxDefaultPackagesVol.log_info("Packages in use: %r", bundles)
+        finally:
+            JBoxDefaultPackagesVol.LOCK.release()
+
+    @staticmethod
+    def get_disk_for_user(user_email):
+        JBoxDefaultPackagesVol.log_debug("creating default packages mounted disk for %s", user_email)
+        disk_path = os.path.join(JBoxDefaultPackagesVol.FS_LOC, JBoxDefaultPackagesVol.CURRENT_BUNDLE)
+        pkgvol = JBoxDefaultPackagesVol(disk_path, user_email=user_email)
+        return pkgvol
+
+    @staticmethod
+    def is_mount_path(fs_path):
+        return fs_path.startswith(JBoxDefaultPackagesVol.FS_LOC)
+
+    @staticmethod
+    def get_disk_from_container(cid):
+        mounts_used = JBoxDefaultPackagesVol._get_package_mounts_used(cid)
+        if len(mounts_used) == 0:
+            return None
+
+        mount_used = mounts_used[0]
+        disk_path = os.path.join(JBoxDefaultPackagesVol.FS_LOC, str(mount_used))
+        container_name = JBoxVol.get_cname(cid)
+        sessname = container_name[1:]
+        return JBoxDefaultPackagesVol(disk_path, sessname=sessname)
+
+    @staticmethod
+    def refresh_user_home_image():
+        if not JBoxDefaultPackagesVol._has_unpacked_julia_packages():
+            JBoxDefaultPackagesVol._unpack_julia_packages()
+            JBoxDefaultPackagesVol._del_unused_package_extracts()
+
+    def release(self, backup=False):
+        pass
+
+    @staticmethod
+    def disk_ids_used_pct():
+        return 0
+
+    @staticmethod
+    def _has_unpacked_julia_packages():
+        pkg_name = os.path.basename(JBoxVol.PKG_IMG).split('.')[0]
+        pkgdir = os.path.join(JBoxDefaultPackagesVol.FS_LOC, pkg_name)
+        if os.path.exists(pkgdir):
+            JBoxDefaultPackagesVol.log_info("Packages folder %s exists. Reusing...", pkgdir)
+            # set PKG_CURRENT to the existing folder
+            JBoxDefaultPackagesVol.CURRENT_BUNDLE = pkg_name
+            return True
+        JBoxDefaultPackagesVol.log_info("Packages folder %s does not exist.", pkgdir)
+        return False
+
+    @staticmethod
+    def _unpack_julia_packages():
+        pkg_name = os.path.basename(JBoxVol.PKG_IMG).split('.')[0]
+        pkgdir = os.path.join(JBoxDefaultPackagesVol.FS_LOC, pkg_name)
+        if os.path.exists(pkgdir):
+            JBoxDefaultPackagesVol.log_debug("Packages folder exists %s. Deleting...", pkgdir)
+            ensure_delete(pkgdir, include_itself=True)
+            JBoxDefaultPackagesVol.log_debug("Packages folder deleted %s", pkgdir)
+
+        JBoxDefaultPackagesVol.log_debug("Will unpack packages to %s", pkgdir)
+        os.mkdir(pkgdir)
+        JBoxDefaultPackagesVol.log_debug("Created packages folder")
+
+        # unpack the latest image from PKG_IMG
+        with tarfile.open(JBoxVol.PKG_IMG, 'r:gz') as pkgs:
+            pkgs.extractall(pkgdir)
+
+        JBoxDefaultPackagesVol.CURRENT_BUNDLE = pkg_name
+        JBoxDefaultPackagesVol.log_info("Current packages folder set to %s", pkgdir)
+
+    @staticmethod
+    def _del_unused_package_extracts(usedpkgs=None):
+        if usedpkgs is None:
+            usedpkgs = JBoxDefaultPackagesVol.BUNDLES_IN_USE
+
+        # usedpkgs is the list of volumes mounted by all containers
+        currdirname = os.path.basename(JBoxDefaultPackagesVol.CURRENT_BUNDLE)
+        for pkgdir in os.listdir(JBoxDefaultPackagesVol.FS_LOC):
+            dirname = os.path.basename(pkgdir)
+            if dirname not in usedpkgs and dirname != currdirname:
+                # no container uses it, delete
+                JBoxDefaultPackagesVol.log_info("Deleting unused packages folder %s", dirname)
+                ensure_delete(os.path.join(JBoxDefaultPackagesVol.FS_LOC, dirname), include_itself=True)

--- a/scripts/maintain/upload_user_home.py
+++ b/scripts/maintain/upload_user_home.py
@@ -26,23 +26,29 @@ if __name__ == "__main__":
     VolMgr.configure()
 
     ts = JBoxVol._get_user_home_timestamp()
-    VolMgr.log_debug("user_home_timestamp: %s", ts.strftime("%Y%m%d_%H%M"))
+    tsstr = ts.strftime("%Y%m%d_%H%M")
+    VolMgr.log_debug("user_home_timestamp: %s", tsstr)
 
     img_dir, img_file = os.path.split(JBoxVol.USER_HOME_IMG)
-    new_img_file_name = 'user_home_' + ts.strftime("%Y%m%d_%H%M") + '.tar.gz'
+    new_img_file_name = 'user_home_' + tsstr + '.tar.gz'
     new_img_file = os.path.join(img_dir, new_img_file_name)
     shutil.copyfile(JBoxVol.USER_HOME_IMG, new_img_file)
 
-    VolMgr.log_debug("new image file is at : %s", new_img_file)
+    new_pkg_file_name = 'julia_packages_' + tsstr + '.tar.gz'
+    new_pkg_file = os.path.join(img_dir, new_pkg_file_name)
+    shutil.copyfile(JBoxVol.PKG_IMG, new_pkg_file)
+
+    VolMgr.log_debug("new image files : %s, %s", new_img_file, new_pkg_file)
 
     bucket = 'juliabox-user-home-templates'
 
-    VolMgr.log_debug("pushing new image file to s3 at: %s", bucket)
+    VolMgr.log_debug("pushing new image files to s3 at: %s", bucket)
     CloudHost.push_file_to_s3(bucket, new_img_file)
+    CloudHost.push_file_to_s3(bucket, new_pkg_file)
 
     # JuliaBoxTest JuliaBox
     clusters = sys.argv[1] if (len(sys.argv) > 1) else ['JuliaBoxTest']
 
     for cluster in clusters:
         VolMgr.log_debug("setting image for cluster: %s", cluster)
-        JBoxDynConfig.set_user_home_image(cluster, bucket, new_img_file_name)
+        JBoxDynConfig.set_user_home_image(cluster, bucket, new_pkg_file_name, new_img_file_name)


### PR DESCRIPTION
This changes the way JuliaBox bundles Julia packages. Package bundles are now available as a volume plugin.

Containers can now have the following types of volumes mounted, providing:
    - home folder
    - package bundle

The default plugin implementation has the following behavior:
    - package bundle is mounted on to a read-only mount point at `/opt/julia_packages` in the container
    - package bundles are now shared across all containers
    - package bundles are updated periodically and older bundles are purged
    - packages available in the bundle can also be listed from the JuliaBox settings screen
    - in future it will be possible to choose between package bundles

Users now can install and maintain their own persistent packages in `~/.julia` folder. User installed packages override default packages.

This also updates Julia version to v0.3.10.