### PR TITLE
mount EBS volumes from within docker, script changes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,4 +37,4 @@ WORKDIR /home/juser
 # 8998: ipython port for julia
 EXPOSE  4200 8000 8998
 
-ENTRYPOINT /usr/bin/supervisord -n -c /home/juser/.juliabox/supervisord.conf -l /home/juser/.juliabox/supervisord.log -j /home/juser/.juliabox/supervisord.pid -q /home/juser/.juliabox
+ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/home/juser/.juliabox/supervisord.conf", "-l", "/home/juser/.juliabox/supervisord.log", "-j", "/home/juser/.juliabox/supervisord.pid", "-q", "/home/juser/.juliabox"]

--- a/engine/Dockerfile.daemon
+++ b/engine/Dockerfile.daemon
@@ -9,6 +9,24 @@ MAINTAINER Tanmay Mohapatra
 # For proxying to work efficiently, it may be best to run the container on host network stack
 EXPOSE 8889 8890
 
+# mount host /proc to get control of all processes
+VOLUME /hostproc
+
+# let juser mount volumes in other namespaces
+RUN pip install nsenter
+#RUN git clone https://github.com/tanmaykm/python-nsenter.git \
+#    && cd python-nsenter \
+#    && git checkout procarg \
+#    && python setup.py install \
+#    && cd .. \
+#    && rm -rf python-nsenter
+
+RUN echo "juser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Provide env with command prefix required to access host mnt namespace
+ENV HOST_MNT_PFX="nsenter --target 1 --proc /hostproc --mnt --" \
+    HOST_IPC_PFX="nsenter --target 1 --proc /hostproc --ipc --"
+
 USER juser
 
 ENTRYPOINT ["/jboxengine/src/jboxd.py"]

--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -5,13 +5,13 @@
     # debug:10, info:20, warning:30, error:40
     "jbox_log_level": 10,
     "root_log_level": 40,
-    "gauth" : $$GAUTH,
-    "invite_only" : $$INVITE,
-    
+    # Use Google Authentication (True/False)
+    "gauth" : True,
+
     # Number of active containers to allow per instance
-    "numlocalmax" : $$NUM_LOCALMAX,
+    "numlocalmax" : 30,
     # Number of disks available to be mounted to images
-    "numdisksmax" : $$NUM_DISKSMAX,
+    "numdisksmax" : 30,
     # Maximum number of hops through the load balancer till the installation is declared overloaded
     "numhopmax": 10,
     
@@ -19,7 +19,7 @@
     "sesskey" : "$$SESSKEY",
     
     # Users that have access to the admin tab
-    "admin_users" : ["$$ADMIN_USER"],
+    "admin_users" : [],
     
     # Sessions which will not be timed out and auto-cleaned up
     "protected_sessions" : [],
@@ -37,14 +37,14 @@
     # Seconds to wait before clearing an inactive session, for example, when the user closes the browser window (protected_sessions are not affected)
     "inactivity_timeout" : 300,
     # Upper time limit for a user session before it is auto-deleted. 0 means never expire (protected_sessions are not affected)
-    "expire" : $$EXPIRE,
+    "expire" : 0,
 
     # The docker image to launch
-    "docker_image" : "$$DOCKER_IMAGE",
+    "docker_image" : "juliabox/juliabox",
     
     "google_oauth": {
-        "key": "$$CLIENT_ID", 
-        "secret": "$$CLIENT_SECRET"
+        "key": "",
+        "secret": ""
     },
     
     "cloud_host": {

--- a/engine/src/juliabox/cloud/awscluster.py
+++ b/engine/src/juliabox/cloud/awscluster.py
@@ -32,12 +32,11 @@ class Cluster(CloudHost):
             else:
                     return float(sum(lst[(len(lst)/2)-1:(len(lst)/2)+1]))/2.0
 
-        def add_price(avzone, price):
-            if avzone in avzone_pricevals:
-                pricevals = avzone_pricevals[avzone]
+        def add_price(az, price):
+            if az in avzone_pricevals:
+                pricevals = avzone_pricevals[az]
             else:
-                pricevals = []
-                avzone_pricevals[avzone] = pricevals
+                avzone_pricevals[az] = pricevals = []
             pricevals.append(price)
 
         while True:

--- a/engine/src/juliabox/cloud/awsebsvol.py
+++ b/engine/src/juliabox/cloud/awsebsvol.py
@@ -1,0 +1,321 @@
+__author__ = 'tan'
+import datetime
+import time
+import os
+import sh
+#import stat
+import pytz
+
+from juliabox.cloud.aws import CloudHost
+from juliabox.jbox_util import retry, parse_iso_time, create_host_mnt_command
+
+
+class EBSVol(CloudHost):
+    SH_MOUNT = None
+    SH_UMOUNT = None
+    SH_LIST_DIR = None
+
+    # @staticmethod
+    # def _get_block_device_mapping(instance_id):
+    #     maps = CloudHost.connect_ec2().get_instance_attribute(instance_id=instance_id,
+    #                                                           attribute='blockDeviceMapping')['blockDeviceMapping']
+    #     idmap = {}
+    #     for dev_path, dev in maps.iteritems():
+    #         idmap[dev_path] = dev.volume_id
+    #     return idmap
+
+    @staticmethod
+    def configure_host_commands():
+        if EBSVol.SH_LIST_DIR is None:
+            EBSVol.SH_LIST_DIR = create_host_mnt_command("ls -la")
+        if EBSVol.SH_MOUNT is None:
+            EBSVol.SH_MOUNT = create_host_mnt_command("mount")
+        if EBSVol.SH_UMOUNT is None:
+            EBSVol.SH_UMOUNT = create_host_mnt_command("umount")
+
+    @staticmethod
+    def _mount_device(dev_id, mount_dir):
+        EBSVol.configure_host_commands()
+        t1 = time.time()
+        device = os.path.join('/dev', dev_id)
+        mount_point = os.path.join(mount_dir, dev_id)
+        actual_mount_point = EBSVol._get_mount_point(dev_id)
+        if actual_mount_point == mount_point:
+            EBSVol.log_debug("Device %s already mounted at %s", device, mount_point)
+            return
+        elif actual_mount_point is None:
+            EBSVol.log_debug("Mounting device %s at %s", device, mount_point)
+            res = EBSVol.SH_MOUNT(mount_point)  # the mount point must be mentioned in fstab file
+            if res.exit_code != 0:
+                raise Exception("Failed to mount device %s at %s. Error code: %d", device, mount_point, res.exit_code)
+        else:
+            raise Exception("Device already mounted at " + actual_mount_point)
+        tdiff = int(time.time() - t1)
+        EBSVol.publish_stats("EBSMountTime", "Count", tdiff)
+
+    @staticmethod
+    def _get_volume(vol_id):
+        vols = CloudHost.connect_ec2().get_all_volumes([vol_id])
+        if len(vols) == 0:
+            return None
+        return vols[0]
+
+    @staticmethod
+    def _get_volume_attach_info(vol_id):
+        vol = EBSVol._get_volume(vol_id)
+        if vol is None:
+            return None, None
+        att = vol.attach_data
+        return att.instance_id, att.device
+
+    @staticmethod
+    def unmount_device(dev_id, mount_dir):
+        EBSVol.configure_host_commands()
+        mount_point = os.path.join(mount_dir, dev_id)
+        actual_mount_point = EBSVol._get_mount_point(dev_id)
+        if actual_mount_point is None:
+            return  # not mounted
+        t1 = time.time()
+        if mount_point != actual_mount_point:
+            EBSVol.log_warn("Mount point expected: %s, actual: %r. Taking actual.", mount_point, actual_mount_point)
+            mount_point = actual_mount_point
+        EBSVol.log_debug("Unmounting dev_id: %r from %r", dev_id, mount_point)
+        res = EBSVol.SH_UMOUNT(mount_point)  # the mount point must be mentioned in fstab file
+        if res.exit_code != 0:
+            raise Exception("Device could not be unmounted from " + mount_point)
+        tdiff = int(time.time() - t1)
+        EBSVol.publish_stats("EBSUnmountTime", "Count", tdiff)
+
+    @staticmethod
+    def _get_mount_point(dev_id):
+        EBSVol.configure_host_commands()
+        device = os.path.join('/dev', dev_id)
+        for line in EBSVol.SH_MOUNT():
+            if line.startswith(device):
+                return line.split()[2]
+        return None
+
+    @staticmethod
+    def _device_exists(dev):
+        try:
+            line = EBSVol.SH_LIST_DIR(dev)
+            line = str(line)
+            # look for b indicating block device.
+            # use stat instead?
+            return len(line) > 0 and line[0] == 'b'
+        except:
+            EBSVol.log_exception("Exception waiting for device state")
+            return False
+
+    # @staticmethod
+    # def _device_exists(dev):
+    #     try:
+    #         mode = os.stat(dev).st_mode
+    #     except OSError:
+    #         return False
+    #     return stat.S_ISBLK(mode)
+
+    @staticmethod
+    @retry(10, 0.5, backoff=1.5)
+    def _wait_for_device(dev):
+        return EBSVol._device_exists(dev)
+
+    @staticmethod
+    def _ensure_volume_available(vol_id, force_detach=False):
+        conn = CloudHost.connect_ec2()
+        vol = EBSVol._get_volume(vol_id)
+        if vol is None:
+            raise Exception("Volume not found: " + vol_id)
+
+        if CloudHost._state_check(vol, 'available'):
+            return True
+
+        # volume may be attached
+        instance_id = CloudHost.instance_id()
+        att_instance_id, att_device = EBSVol._get_volume_attach_info(vol_id)
+
+        if (att_instance_id is None) or (att_instance_id == instance_id):
+            return True
+
+        if force_detach:
+            EBSVol.log_warn("Forcing detach of volume %s", vol_id)
+            conn.detach_volume(vol_id)
+            CloudHost._wait_for_status(vol, 'available')
+
+        if not CloudHost._state_check(vol, 'available'):
+            raise Exception("Volume not available: " + vol_id +
+                            ", attached to: " + att_instance_id +
+                            ", state: " + vol.status)
+
+    @staticmethod
+    def _attach_free_volume(vol_id, dev_id, mount_dir):
+        conn = CloudHost.connect_ec2()
+        instance_id = CloudHost.instance_id()
+        device = os.path.join('/dev', dev_id)
+        mount_point = os.path.join(mount_dir, dev_id)
+        vol = EBSVol._get_volume(vol_id)
+
+        EBSVol.log_info("Attaching volume %s at %s", vol_id, device)
+        t1 = time.time()
+        conn.attach_volume(vol_id, instance_id, device)
+
+        if not CloudHost._wait_for_status(vol, 'in-use'):
+            EBSVol.log_error("Could not attach volume %s", vol_id)
+            raise Exception("Volume could not be attached. Volume id: " + vol_id)
+
+        if not EBSVol._wait_for_device(device):
+            EBSVol.log_error("Could not attach volume %s to device %s", vol_id, device)
+            raise Exception("Volume could not be attached. Volume id: " + vol_id + ", device: " + device)
+        tdiff = int(time.time() - t1)
+        CloudHost.publish_stats("EBSAttachTime", "Count", tdiff)
+
+        EBSVol._mount_device(dev_id, mount_dir)
+        return device, mount_point
+
+    @staticmethod
+    def _get_mapped_volumes(instance_id=None):
+        if instance_id is None:
+            instance_id = CloudHost.instance_id()
+
+        return CloudHost.connect_ec2().get_instance_attribute(instance_id=instance_id,
+                                                              attribute='blockDeviceMapping')['blockDeviceMapping']
+
+    @staticmethod
+    def get_volume_id_from_device(dev_id):
+        device = os.path.join('/dev', dev_id)
+        maps = EBSVol._get_mapped_volumes()
+        EBSVol.log_debug("Devices mapped: %r", maps)
+        if device not in maps:
+            return None
+        return maps[device].volume_id
+
+    @staticmethod
+    def is_snapshot_complete(snap_id):
+        snaps = CloudHost.connect_ec2().get_all_snapshots([snap_id])
+        if len(snaps) == 0:
+            raise Exception("Snapshot not found with id " + str(snap_id))
+        snap = snaps[0]
+        return snap.status == 'completed'
+
+    @staticmethod
+    def get_snapshot_age(snap_id):
+        snaps = CloudHost.connect_ec2().get_all_snapshots([snap_id])
+        if len(snaps) == 0:
+            raise Exception("Snapshot not found with id " + str(snap_id))
+        snap = snaps[0]
+
+        st = parse_iso_time(snap.start_time)
+        nt = datetime.datetime.now(pytz.utc)
+        return nt - st
+
+    @staticmethod
+    def create_new_volume(snap_id, dev_id, mount_dir, tag=None, disk_sz_gb=1):
+        EBSVol.configure_host_commands()
+        EBSVol.log_info("Creating volume. Tag: %s, Snapshot: %s. Mounted: %s, %s", tag, snap_id, dev_id, mount_dir)
+        conn = CloudHost.connect_ec2()
+        vol = conn.create_volume(disk_sz_gb, CloudHost.zone(),
+                                 snapshot=snap_id,
+                                 volume_type='gp2')
+                                 # volume_type='io1',
+                                 # iops=30*disk_sz_gb)
+        CloudHost._wait_for_status(vol, 'available')
+        vol_id = vol.id
+        EBSVol.log_info("Created volume with id %s", vol_id)
+
+        if tag is not None:
+            conn.create_tags([vol_id], {"Name": tag})
+            EBSVol.log_info("Added tag %s to volume with id %s", tag, vol_id)
+
+        mnt_info = EBSVol._attach_free_volume(vol_id, dev_id, mount_dir)
+        return mnt_info[0], mnt_info[1], vol_id
+
+    # @staticmethod
+    # def detach_mounted_volume(dev_id, mount_dir, delete=False):
+    #     CloudHelper.log_info("Detaching volume mounted at device " + dev_id)
+    #     vol_id = CloudHelper.get_volume_id_from_device(dev_id)
+    #     CloudHelper.log_debug("Device " + dev_id + " maps volume " + vol_id)
+    #
+    #     # find the instance and device to which the volume is mapped
+    #     instance, device = CloudHelper._get_volume_attach_info(vol_id)
+    #     if instance is None:  # the volume is not mounted
+    #         return
+    #
+    #     # if mounted to current instance, also unmount the device
+    #     if instance == CloudHelper.instance_id():
+    #         dev_id = device.split('/')[-1]
+    #         CloudHelper.unmount_device(dev_id, mount_dir)
+    #         time.sleep(1)
+    #
+    #     return CloudHelper.detach_volume(vol_id, delete=delete)
+
+    @staticmethod
+    def detach_volume(vol_id, delete=False):
+        EBSVol.configure_host_commands()
+        # find the instance and device to which the volume is mapped
+        instance, device = EBSVol._get_volume_attach_info(vol_id)
+        conn = CloudHost.connect_ec2()
+        if instance is not None:  # the volume is attached
+            EBSVol.log_debug("Detaching %s from instance %s device %r", vol_id, instance, device)
+            vol = EBSVol._get_volume(vol_id)
+            t1 = time.time()
+            conn.detach_volume(vol_id, instance, device)
+            if not CloudHost._wait_for_status_extended(vol, 'available'):
+                raise Exception("Volume could not be detached " + vol_id)
+            tdiff = int(time.time() - t1)
+            CloudHost.publish_stats("EBSDetachTime", "Count", tdiff)
+        if delete:
+            EBSVol.log_debug("Deleting %s", vol_id)
+            conn.delete_volume(vol_id)
+
+    @staticmethod
+    def attach_volume(vol_id, dev_id, mount_dir, force_detach=False):
+        """
+        In order for EBS volumes to be mountable on the host system, JuliaBox relies on the fstab file must have
+        pre-filled mount points with options to allow non-root user to mount/unmount them. This necesseciates that
+        the mount point and device ids association be fixed beforehand. So we follow a convention where /dev/dev_id
+        will be mounted at /mount_dir/dev_id
+
+        Returns the device path and mount path where the volume was attached.
+
+        If the volume is already mounted on the current instance, the existing device and mount paths are returned,
+        which may be different from what was requested.
+
+        :param vol_id: EBS volume id to mount
+        :param dev_id: volume will be attached at /dev/dev_id
+        :param mount_dir: device will be mounted at /mount_dir/dev_id
+        :param force_detach: detach the volume from any other instance that might have attached it
+        :return: device_path, mount_path
+        """
+        EBSVol.configure_host_commands()
+        EBSVol.log_info("Attaching volume %s to dev_id %s at %s", vol_id, dev_id, mount_dir)
+        EBSVol._ensure_volume_available(vol_id, force_detach=force_detach)
+        att_instance_id, att_device = EBSVol._get_volume_attach_info(vol_id)
+
+        if att_instance_id is None:
+            return EBSVol._attach_free_volume(vol_id, dev_id, mount_dir)
+        else:
+            EBSVol.log_warn("Volume %s already attached to %s at %s", vol_id, att_instance_id, att_device)
+            EBSVol._mount_device(dev_id, mount_dir)
+            return att_device, os.path.join(mount_dir, dev_id)
+
+    @staticmethod
+    def snapshot_volume(vol_id=None, dev_id=None, tag=None, description=None, wait_till_complete=True):
+        EBSVol.configure_host_commands()
+        if dev_id is not None:
+            vol_id = EBSVol.get_volume_id_from_device(dev_id)
+        if vol_id is None:
+            EBSVol.log_warn("No volume to snapshot. vol_id: %r, dev_id %r", vol_id, dev_id)
+            return
+        vol = EBSVol._get_volume(vol_id)
+        EBSVol.log_info("Creating snapshot for volume: %s", vol_id)
+        snap = vol.create_snapshot(description)
+        if wait_till_complete and (not CloudHost._wait_for_status_extended(snap, 'completed')):
+            raise Exception("Could not create snapshot for volume " + vol_id)
+        EBSVol.log_info("Created snapshot %s for volume %s", snap.id, vol_id)
+        if tag is not None:
+            CloudHost.connect_ec2().create_tags([snap.id], {'Name': tag})
+        return snap.id
+
+    @staticmethod
+    def delete_snapshot(snapshot_id):
+        CloudHost.connect_ec2().delete_snapshot(snapshot_id)

--- a/engine/src/juliabox/jbox_util.py
+++ b/engine/src/juliabox/jbox_util.py
@@ -1,4 +1,5 @@
 import os
+import sh
 import sys
 import time
 import errno
@@ -123,6 +124,16 @@ def unquote(s):
         return s[1:-1]
     else:
         return s
+
+
+def create_host_mnt_command(cmd):
+    pfx = os.getenv('HOST_MNT_PFX')
+    if pfx:
+        cmd = pfx + " " + cmd
+    hcmd = sh.sudo
+    for comp in cmd.split():
+        hcmd = hcmd.bake(comp)
+    return hcmd
 
 
 class JBoxCfg(object):

--- a/engine/src/juliabox/plugins/vol_ebs/ebs.py
+++ b/engine/src/juliabox/plugins/vol_ebs/ebs.py
@@ -1,10 +1,14 @@
 import os
 import threading
 import time
+#import sh
+from string import ascii_lowercase
 
+from juliabox.cloud.awsebsvol import EBSVol
 from juliabox.cloud.aws import CloudHost
 from juliabox.db import JBoxSessionProps
 from juliabox.jbox_util import unique_sessname, JBoxCfg
+# from juliabox.jbox_util import create_host_mnt_command
 from juliabox.vol import JBoxVol
 from disk_state_tbl import JBoxDiskState
 from juliabox.jbox_container import JBoxContainer
@@ -21,18 +25,26 @@ class JBoxEBSVol(JBoxVol):
     DISK_RESERVE_TIME = {}
     DISK_TEMPLATE_SNAPSHOT = None
     LOCK = None
+    # SH_READ_FSTAB = None
 
     @staticmethod
     def configure():
+        # JBoxEBSVol.SH_READ_FSTAB = create_host_mnt_command("cat /etc/fstab")
         num_disks_max = JBoxCfg.get('numdisksmax')
         JBoxEBSVol.FS_LOC = os.path.expanduser(JBoxCfg.get('cloud_host.ebs_mnt_location'))
         JBoxEBSVol.DISK_LIMIT = 1
         JBoxEBSVol.MAX_DISKS = num_disks_max
         JBoxEBSVol.DISK_TEMPLATE_SNAPSHOT = JBoxCfg.get('cloud_host.ebs_template')
 
-        JBoxEBSVol.DEVICES = JBoxEBSVol._get_configured_devices(JBoxEBSVol.FS_LOC)
-        if len(JBoxEBSVol.DEVICES) < num_disks_max:
-            raise Exception("Not enough EBS mount points configured")
+        JBoxEBSVol.DEVICES = JBoxEBSVol._guess_configured_devices('xvd', num_disks_max)
+        JBoxEBSVol.log_debug("Assuming %d EBS volumes configured in range xvdba..xvdcz", len(JBoxEBSVol.DEVICES))
+        # JBoxEBSVol.DEVICES = JBoxEBSVol._get_configured_devices(JBoxEBSVol.FS_LOC)
+        # if len(JBoxEBSVol.DEVICES) < num_disks_max:
+        #     JBoxEBSVol.log_error("Not enough EBS mount points configured. Found %d, configured %d",
+        #                          len(JBoxEBSVol.DEVICES), num_disks_max)
+        #     raise Exception("Not enough EBS mount points configured")
+        # else:
+        #     JBoxEBSVol.log_debug("Found %d EBS volumes configured", len(JBoxEBSVol.DEVICES))
 
         JBoxEBSVol.LOCK = threading.Lock()
         JBoxEBSVol.refresh_disk_use_status()
@@ -41,22 +53,31 @@ class JBoxEBSVol(JBoxVol):
     def get_disk_allocated_size(cls):
         return JBoxEBSVol.DISK_LIMIT * 1000000000
 
-    @staticmethod
-    def _id_from_device(dev_path):
-        return dev_path.split('/')[-1]
+    # @staticmethod
+    # def _id_from_device(dev_path):
+    #     return dev_path.split('/')[-1]
+    #
+    # @staticmethod
+    # def _get_configured_devices(fs_loc):
+    #     devices = []
+    #     for line in JBoxEBSVol.SH_READ_FSTAB():
+    #         line = line.strip()
+    #         if (len(line) == 0) or line.startswith('#'):
+    #             continue
+    #         comps = line.split()
+    #         if (len(comps) == 6) and comps[1].startswith(fs_loc):
+    #             device = comps[0]
+    #             devices.append(JBoxEBSVol._id_from_device(device))
+    #     return devices
 
     @staticmethod
-    def _get_configured_devices(fs_loc):
+    def _guess_configured_devices(devidpfx, num_disks):
         devices = []
-        with open('/etc/fstab', 'r') as fstab:
-            for line in fstab:
-                line = line.strip()
-                if (len(line) == 0) or line.startswith('#'):
-                    continue
-                comps = line.split()
-                if (len(comps) == 6) and comps[1].startswith(fs_loc):
-                    device = comps[0]
-                    devices.append(JBoxEBSVol._id_from_device(device))
+        for pfx1 in 'bc':
+            for pfx2 in ascii_lowercase:
+                devices.append(devidpfx+pfx1+pfx2)
+                if len(devices) == num_disks:
+                    return devices
         return devices
 
     @staticmethod
@@ -166,17 +187,15 @@ class JBoxEBSVol(JBoxVol):
 
             JBoxEBSVol.log_debug("will use snapshot id %s for %s", snap_id, user_email)
 
-            _dev_path, mnt_path, vol_id = CloudHost.create_new_volume(snap_id, disk_id,
-                                                                      JBoxEBSVol.FS_LOC,
-                                                                      tag=user_email,
-                                                                      disk_sz_gb=JBoxEBSVol.DISK_LIMIT)
+            _dev_path, mnt_path, vol_id = EBSVol.create_new_volume(snap_id, disk_id, JBoxEBSVol.FS_LOC,
+                                                                   tag=user_email, disk_sz_gb=JBoxEBSVol.DISK_LIMIT)
             existing_disk = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION,
                                           user_id=user_email,
                                           volume_id=vol_id,
                                           attach_time=None,
                                           create=True)
         else:
-            _dev_path, mnt_path = CloudHost.attach_volume(existing_disk.get_volume_id(), disk_id, JBoxEBSVol.FS_LOC)
+            _dev_path, mnt_path = EBSVol.attach_volume(existing_disk.get_volume_id(), disk_id, JBoxEBSVol.FS_LOC)
             existing_disk.set_attach_time()
             snap_id = None
 
@@ -220,24 +239,23 @@ class JBoxEBSVol(JBoxVol):
         sess_props = JBoxSessionProps(self.sessname)
         desc = sess_props.get_user_id() + " JuliaBox Backup"
         disk_id = self.disk_path.split('/')[-1]
-        snap_id = CloudHost.snapshot_volume(dev_id=disk_id, tag=self.sessname, description=desc,
-                                            wait_till_complete=False)
-        #old_snap_id = sess_props.get_snapshot_id()
-        #sess_props.set_snapshot_id(snap_id)
-        #sess_props.save()
-        #if old_snap_id is not None:
+        snap_id = EBSVol.snapshot_volume(dev_id=disk_id, tag=self.sessname, description=desc, wait_till_complete=False)
+        # old_snap_id = sess_props.get_snapshot_id()
+        # sess_props.set_snapshot_id(snap_id)
+        # sess_props.save()
+        # if old_snap_id is not None:
         #    CloudHost.delete_snapshot(old_snap_id)
         return snap_id
 
     def release(self, backup=False):
         disk_id = self.disk_path.split('/')[-1]
-        CloudHost.unmount_device(disk_id, JBoxEBSVol.FS_LOC)
+        EBSVol.unmount_device(disk_id, JBoxEBSVol.FS_LOC)
         if backup:
             snap_id = self._backup()
         else:
             snap_id = None
-        vol_id = CloudHost.get_volume_id_from_device(disk_id)
-        CloudHost.detach_volume(vol_id, delete=False)
+        vol_id = EBSVol.get_volume_id_from_device(disk_id)
+        EBSVol.detach_volume(vol_id, delete=False)
 
         sess_props = JBoxSessionProps(self.sessname)
         existing_disk = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION,

--- a/engine/src/juliabox/srvr_jboxd.py
+++ b/engine/src/juliabox/srvr_jboxd.py
@@ -2,7 +2,7 @@ import threading
 import json
 import time
 import signal
-import os
+#import os
 import sys
 
 from cloud.aws import CloudHost
@@ -145,8 +145,8 @@ class JBoxd(LoggerMixin):
 
             rate_per_second -= 1
             if rate_per_second <= 0:
-                time.sleep(1)
                 rate_per_second = min(JBoxd.MAX_ACTIVATIONS_PER_SEC, rate)
+                time.sleep(1)
 
     @staticmethod
     @jboxd_method

--- a/host/supervisord.conf
+++ b/host/supervisord.conf
@@ -26,7 +26,7 @@ stderr_logfile_backups = 2
 stderr_logfile_maxbytes = 1MB
 
 [program:enginedaemon]
-command = docker run -a stdout -a stderr --rm --name=enginedaemon_jboxsvc --privileged --net=host -v /var/run/docker.sock:/var/run/docker.sock -v /jboxengine/data:/jboxengine/data -v %(here)s/../engine/logs:/jboxengine/logs juliabox/enginedaemon
+command = docker run -a stdout -a stderr --rm --name=enginedaemon_jboxsvc --privileged --net=host -v /proc:/hostproc -v /var/run/docker.sock:/var/run/docker.sock -v /jboxengine/data:/jboxengine/data -v %(here)s/../engine/logs:/jboxengine/logs juliabox/enginedaemon
 directory =  %(here)s/../engine
 process_name = enginedaemon
 stdout_logfile = %(here)s/../engine/logs/enginedaemon.log

--- a/scripts/install/aws/clean_instance.sh
+++ b/scripts/install/aws/clean_instance.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+# Clean up the EC2 instance before building an AMI
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/../../jboxcommon.sh
+
+if [ "root" != `whoami` ]
+then
+    echo "Must be run as superuser"
+    exit 1
+fi
+
+${JBOX_DIR}/scripts/run/stop.sh
+${JBOX_DIR}/scripts/run/clean.sh
+
+\rm -f ${WEBSERVER_CONF_DIR}/conf/nginx.conf
+\rm -f ${ENGINE_CONF_DIR}/tornado.conf
+\rm -f ${ENGINE_CONF_DIR}/jbox.user
+
+\rm -f ${ENGINE_CONF_DIR}/.boto
+\rm -f ${JBOX_DIR}/.jbox_session_key
+
+${JBOX_DIR}/scripts/install/unmount_fs.sh /jboxengine/data 1
+
+truncate -s 0 .bash_history
+truncate -s 0 /var/awslogs/etc/aws.conf
+
+for id in `docker ps -a | cut -d" " -f1 | grep -v CONTAINER`; do echo $id; docker kill $id; docker rm $id; done

--- a/scripts/install/aws/configure_cloudwatch_logs.sh
+++ b/scripts/install/aws/configure_cloudwatch_logs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 5 ]
+then
+    echo "Usage: sudo configure_cloudwatch_logs.sh <log_group_prefix> <jbox_user> <aws_access_key_id> <aws_secret_key> <start_service(0/1)>"
+    exit 1
+fi
+
+if [ "root" != `whoami` ]
+then
+    echo "Must be run as superuser"
+    exit 1
+fi
+
+GROUP_PFX=$1
+JBOX_USER=$2
+AWS_ACCESS_KEY_ID=$3
+AWS_SECRET_KEY=$4
+START_SERVICE=$5
+
+service awslogs stop
+cat > /var/awslogs/etc/aws.conf <<DELIM
+[plugins]
+cwlogs = cwlogs
+[default]
+region = us-east-1
+aws_access_key_id = ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key = ${AWS_SECRET_KEY}
+DELIM
+
+sudo -u ${JBOX_USER} cat > /home/${JBOX_USER}/cloud_watch_logs.cfg <<DELIM
+[general]
+state_file = /var/awslogs/state/agent-state
+
+[/var/log/syslog]
+file = /var/log/syslog
+log_group_name = ${GROUP_PFX}/var/log/syslog
+log_stream_name = {instance_id}
+datetime_format = %b %d %H:%M:%S
+initial_position = start_of_file
+buffer_duration = 5000
+
+[/home/${JBOX_USER}/JuliaBox/webserver/logs/webserver_err.log]
+file = /home/${JBOX_USER}/JuliaBox/webserver/logs/webserver_err.log
+log_group_name = ${GROUP_PFX}/webserver/logs/webserver_err.log
+log_stream_name = {instance_id}
+datetime_format = %Y/%m/%d %H:%M:%S
+initial_position = start_of_file
+buffer_duration = 5000
+
+[/home/${JBOX_USER}/JuliaBox/engine/engineinteractive_err.log]
+file = /home/${JBOX_USER}/JuliaBox/engine/engineinteractive_err.log
+log_group_name = ${GROUP_PFX}/engine/engineinteractive_err.log
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%d %H:%M:%S,%z
+initial_position = start_of_file
+buffer_duration = 5000
+
+[/home/${JBOX_USER}/JuliaBox/engine/enginedaemon_err.log]
+file = /home/${JBOX_USER}/JuliaBox/engine/enginedaemon_err.log
+log_group_name = ${GROUP_PFX}/engine/enginedaemon_err.log
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%d %H:%M:%S,%z
+initial_position = start_of_file
+buffer_duration = 5000
+
+[/home/${JBOX_USER}/JuliaBox/engine/engineinteractive.log]
+file = /home/${JBOX_USER}/JuliaBox/engine/engineinteractive.log
+log_group_name = ${GROUP_PFX}/engine/engineinteractive.log
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%d %H:%M:%S,%z
+initial_position = start_of_file
+buffer_duration = 5000
+
+[/home/${JBOX_USER}/JuliaBox/engine/enginedaemon.log]
+file = /home/${JBOX_USER}/JuliaBox/engine/enginedaemon.log
+log_group_name = ${GROUP_PFX}/engine/enginedaemon.log
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%d %H:%M:%S,%z
+initial_position = start_of_file
+buffer_duration = 5000
+DELIM
+
+wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+chmod +x ./awslogs-agent-setup.py
+./awslogs-agent-setup.py -n -r us-east-1 -c /home/${JBOX_USER}/cloud_watch_logs.cfg
+
+if [ $START_SERVICE -eq 1 ]
+then
+    service awslogs start
+fi

--- a/scripts/install/aws/mount_ephemeral.sh
+++ b/scripts/install/aws/mount_ephemeral.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+if [ "root" != `whoami` ]
+then
+    echo "Must be run as superuser"
+    exit 1
+fi
+
+service docker stop
+sleep 5
+mkfs -t ext4 -m 1 -v $1
+mkdir /jboxengine
+mount $1 /jboxengine

--- a/scripts/install/aws/mount_swap.sh
+++ b/scripts/install/aws/mount_swap.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+# Add swap
+
+echo "Adding swap of size $1 MB"
+
+dd if=/dev/zero of=/mnt/swapfile bs=1M count=$1
+chown root:root /mnt/swapfile
+chmod 600 /mnt/swapfile
+mkswap /mnt/swapfile
+swapon /mnt/swapfile

--- a/scripts/install/img_create.sh
+++ b/scripts/install/img_create.sh
@@ -7,9 +7,28 @@ JBOX_DIR=`readlink -e ${DIR}/../..`
 DOCKER_IMAGE=juliabox/juliabox
 DOCKER_IMAGE_VER=$(grep "^# Version:" ${JBOX_DIR}/docker/Dockerfile | cut -d":" -f2)
 
+function build_web_engines {
+    for pycfile in `find $JBOX_DIR} -name "*.pyc" -print`
+    do
+        sudo rm $pycfile
+    done
+
+    for imgspec in webserver,webserver/Dockerfile enginebase,engine/Dockerfile.base enginedaemon,engine/Dockerfile.daemon engineinteractive,engine/Dockerfile.interactive
+    do
+        IFS=","
+        set ${imgspec}
+        IMGTAG="juliabox/$1"
+        DOCKERFILE=${JBOX_DIR}/$2
+        DOCKERDIR=$(dirname ${DOCKERFILE})
+        echo "Building docker image ${IMGTAG} from ${DOCKERFILE} ..."
+        sudo docker build -t ${IMGTAG} -f ${DOCKERFILE} ${DOCKERDIR}
+        unset IFS
+    done
+}
+
 function build_docker_image {
     echo "Building docker image ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} ..."
-    sudo docker build --rm=true -t ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} docker/
+    sudo docker build --rm=true -t ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} ${JBOX_DIR}/docker/
     sudo docker tag -f ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} ${DOCKER_IMAGE}:latest
 }
 
@@ -24,19 +43,25 @@ function make_user_home {
 	${JBOX_DIR}/docker/mk_user_home.sh $1
 }
 
-if [ "$2" == "pull" ]
+cmd=$1
+dataloc=$2
+
+if [ "$cmd" == "pull" ]
 then
     pull_docker_image
-    make_user_home $1
-elif [ "$2" == "build" ]
+    make_user_home "$dataloc"
+elif [ "$cmd" == "build" ]
 then
     build_docker_image
-    make_user_home $1
-elif [ "$2" == "home" ]
+    make_user_home "$dataloc"
+elif [ "$cmd" == "home" ]
 then
-    make_user_home $1
+    make_user_home "$dataloc"
+elif [ "$cmd" == "jbox" ]
+then
+    build_web_engines
 else
-    echo "Usage: img_create.sh <data_location> <pull | build | home>"
+    echo "Usage: img_create.sh <pull | build | home | jbox> <data_location>"
 fi
 
 echo

--- a/scripts/install/jbox_configure.sh
+++ b/scripts/install/jbox_configure.sh
@@ -2,124 +2,27 @@
 # Configure JuliaBox components
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-JBOX_DIR=`readlink -e ${DIR}/../..`
-
 source ${DIR}/../jboxcommon.sh
-
-DOCKER_IMAGE=juliabox/juliabox
-OPT_GOOGLE=0
-OPT_INVITE=0
-NUM_LOCALMAX=2
-NUM_DISKSMAX=2
-EXPIRE=0
-
-function usage {
-  echo
-  echo 'Usage: ./setup.sh -u <admin_username> optional_args'
-  echo ' -u  <username> : Mandatory admin username. If -g option is used, this must be the complete Google email-id'
-  echo ' -g             : Use Google OAuth2 for user authentication. Options -k and -s must be specified.'
-  echo ' -k  <key>      : Google OAuth2 key (client id).'
-  echo ' -s  <secret>   : Google OAuth2 client secret.'
-  echo ' -n  <num>      : Maximum number of active containers. Default 2.'
-  echo ' -v  <num>      : Maximum number of mountable volumes. Default 2.'
-  echo ' -t  <seconds>  : Auto delete containers older than specified seconds. 0 means never expire. Default 0.'
-  echo ' -i             : Install in an invite only mode.'
-  echo
-  echo 'Post setup, additional configuration parameters may be set in jbox.user '
-  echo 'Please see README.md (https://github.com/JuliaLang/JuliaBox) for more details '
-  
-  exit 1
-}
 
 function gen_sesskey {
     echo "Generating random session validation key"
     SESSKEY=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32`
-    echo $SESSKEY > .jbox_session_key
+    echo $SESSKEY > ${HOST_DIR}/.jbox_session_key
 }
 
 function configure_resty_tornado {
-    echo "Setting up nginx.conf ..."
-    sed  s/\$\$NGINX_USER/$USER/g $NGINX_CONF_DIR/nginx.conf.tpl > $NGINX_CONF_DIR/nginx.conf
-    sed  -i s/\$\$ADMIN_KEY/$1/g $NGINX_CONF_DIR/nginx.conf
-
-    sed  -i s/\$\$SESSKEY/$SESSKEY/g $NGINX_CONF_DIR/nginx.conf 
-    sed  s/\$\$SESSKEY/$SESSKEY/g $TORNADO_CONF_DIR/tornado.conf.tpl > $TORNADO_CONF_DIR/tornado.conf
-
-    if test $OPT_GOOGLE -eq 1; then
-        sed  -i s/\$\$GAUTH/True/g $TORNADO_CONF_DIR/tornado.conf
-    else
-        sed  -i s/\$\$GAUTH/False/g $TORNADO_CONF_DIR/tornado.conf
-    fi
-    if test $OPT_INVITE -eq 1; then
-        sed  -i s/\$\$INVITE/True/g $TORNADO_CONF_DIR/tornado.conf
-    else
-        sed  -i s/\$\$INVITE/False/g $TORNADO_CONF_DIR/tornado.conf
-    fi
-
-    sed  -i s/\$\$ADMIN_USER/$ADMIN_USER/g $TORNADO_CONF_DIR/tornado.conf
-    sed  -i s/\$\$NUM_LOCALMAX/$NUM_LOCALMAX/g $TORNADO_CONF_DIR/tornado.conf
-    sed  -i s/\$\$NUM_DISKSMAX/$NUM_DISKSMAX/g $TORNADO_CONF_DIR/tornado.conf
-    sed  -i s/\$\$EXPIRE/$EXPIRE/g $TORNADO_CONF_DIR/tornado.conf
-    sed  -i s,\$\$DOCKER_IMAGE,$DOCKER_IMAGE,g $TORNADO_CONF_DIR/tornado.conf
-    sed  -i s,\$\$CLIENT_SECRET,$CLIENT_SECRET,g $TORNADO_CONF_DIR/tornado.conf
-    sed  -i s,\$\$CLIENT_ID,$CLIENT_ID,g $TORNADO_CONF_DIR/tornado.conf
+    echo "Setting up webserver and engine configurations..."
+    sed  s/\$\$SESSKEY/$SESSKEY/g $WEBSERVER_CONF_DIR/nginx.conf.tpl > $WEBSERVER_CONF_DIR/nginx.conf
+    sed  s/\$\$SESSKEY/$SESSKEY/g $ENGINE_CONF_DIR/tornado.conf.tpl > $ENGINE_CONF_DIR/tornado.conf
 }
 
-
-while getopts  "u:idgn:v:t:k:s:" FLAG
-do
-  if test $FLAG == '?'
-     then
-        usage
-
-  elif test $FLAG == 'u'
-     then
-        ADMIN_USER=$OPTARG
-
-  elif test $FLAG == 'g'
-     then
-        OPT_GOOGLE=1
-
-  elif test $FLAG == 'i'
-     then
-        OPT_INVITE=1
-
-  elif test $FLAG == 'n'
-     then
-        NUM_LOCALMAX=$OPTARG
-
-  elif test $FLAG == 'v'
-     then
-        NUM_DISKSMAX=$OPTARG
-
-  elif test $FLAG == 't'
-     then
-        EXPIRE=$OPTARG
-
-  elif test $FLAG == 'k'
-     then
-        CLIENT_ID=$OPTARG
-
-  elif test $FLAG == 's'
-     then
-        CLIENT_SECRET=$OPTARG
-  fi
-done
-
-if test -v $ADMIN_USER
-  then
-    usage
-fi
-
-
-if [ ! -e .jbox_session_key ]
+if [ ! -e ${HOST_DIR}/.jbox_session_key ]
 then
     gen_sesskey
 fi
-SESSKEY=`cat .jbox_session_key`
+SESSKEY=`cat ${HOST_DIR}/.jbox_session_key`
 
 configure_resty_tornado
 
 echo
 echo "DONE!"
- 

--- a/scripts/install/sys_install.sh
+++ b/scripts/install/sys_install.sh
@@ -6,6 +6,7 @@
 # configure docker to use either AUFS or DEVICEMAPPER
 #DOCKER_FS=AUFS
 DOCKER_FS=DEVICEMAPPER
+NUM_LOCALMAX=30
 
 function sysinstall_pystuff {
     sudo easy_install tornado
@@ -28,16 +29,8 @@ function sysinstall_libs {
 }
 
 function sysinstall_docker {
-    # INSTALL docker as per http://docs.docker.io/en/latest/installation/ubuntulinux/
-    sudo apt-get -y update
-    sudo apt-get -y install linux-image-extra-`uname -r`
-    sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
-    sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
-    sudo apt-get -y update
-    sudo apt-get -y install lxc-docker
-
-    # docker stuff
-    sudo gpasswd -a $USER docker
+    wget -qO- https://get.docker.com/ | sh
+    sudo usermod -aG docker $USER
 }
 
 function configure_docker {

--- a/scripts/jboxcommon.sh
+++ b/scripts/jboxcommon.sh
@@ -1,5 +1,10 @@
-TORNADO_DIR=engine
-TORNADO_CONF_DIR=$TORNADO_DIR/conf
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+JBOX_DIR=`readlink -e ${DIR}/..`
 
-NGINX_DIR=webserver
-NGINX_CONF_DIR=$NGINX_DIR/conf
+ENGINE_DIR=${JBOX_DIR}/engine
+ENGINE_CONF_DIR=${ENGINE_DIR}/conf
+
+WEBSERVER_DIR=${JBOX_DIR}/webserver
+WEBSERVER_CONF_DIR=${WEBSERVER_DIR}/conf
+
+HOST_DIR=${JBOX_DIR}/host

--- a/scripts/maintain/upload_user_home.py
+++ b/scripts/maintain/upload_user_home.py
@@ -9,6 +9,7 @@ import docker
 from juliabox.db import JBoxDynConfig
 from juliabox import db
 from juliabox.jbox_util import JBoxCfg, LoggerMixin
+from juliabox.jbox_container import JBoxContainer
 from juliabox.cloud.aws import CloudHost
 from juliabox.vol import VolMgr, JBoxVol
 
@@ -23,6 +24,7 @@ if __name__ == "__main__":
     LoggerMixin.configure()
     db.configure()
     CloudHost.configure()
+    JBoxContainer.configure()
     VolMgr.configure()
 
     ts = JBoxVol._get_user_home_timestamp()

--- a/scripts/maintain/upload_user_home.py
+++ b/scripts/maintain/upload_user_home.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import shutil
+from os.path import expanduser
 
 import docker
 
@@ -13,8 +14,30 @@ from juliabox.jbox_container import JBoxContainer
 from juliabox.cloud.aws import CloudHost
 from juliabox.vol import VolMgr, JBoxVol
 
+
+def copy_for_upload(tstamp):
+    img_dir, img_file = os.path.split(JBoxVol.USER_HOME_IMG)
+    new_img_file_name = 'user_home_' + tstamp + '.tar.gz'
+    new_img_file = os.path.join(img_dir, new_img_file_name)
+    shutil.copyfile(JBoxVol.USER_HOME_IMG, new_img_file)
+
+    new_pkg_file_name = 'julia_packages_' + tstamp + '.tar.gz'
+    new_pkg_file = os.path.join(img_dir, new_pkg_file_name)
+    shutil.copyfile(JBoxVol.PKG_IMG, new_pkg_file)
+
+    VolMgr.log_debug("new image files : %s, %s", new_img_file, new_pkg_file)
+    return new_img_file, new_pkg_file
+
+
+def copy_for_boot():
+    for f in (JBoxVol.USER_HOME_IMG, JBoxVol.PKG_IMG):
+        dname, fname = os.path.split(f)
+        copyname = expanduser(os.path.join("~", fname))
+        shutil.copyfile(f, copyname)
+
+
 if __name__ == "__main__":
-    conf_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../host/tornado/conf'))
+    conf_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../engine/conf'))
     conf_file = os.path.join(conf_dir, 'tornado.conf')
     user_conf_file = os.path.join(conf_dir, 'jbox.user')
 
@@ -31,26 +54,18 @@ if __name__ == "__main__":
     tsstr = ts.strftime("%Y%m%d_%H%M")
     VolMgr.log_debug("user_home_timestamp: %s", tsstr)
 
-    img_dir, img_file = os.path.split(JBoxVol.USER_HOME_IMG)
-    new_img_file_name = 'user_home_' + tsstr + '.tar.gz'
-    new_img_file = os.path.join(img_dir, new_img_file_name)
-    shutil.copyfile(JBoxVol.USER_HOME_IMG, new_img_file)
-
-    new_pkg_file_name = 'julia_packages_' + tsstr + '.tar.gz'
-    new_pkg_file = os.path.join(img_dir, new_pkg_file_name)
-    shutil.copyfile(JBoxVol.PKG_IMG, new_pkg_file)
-
-    VolMgr.log_debug("new image files : %s, %s", new_img_file, new_pkg_file)
+    imgf, pkgf = copy_for_upload(tsstr)
+    copy_for_boot()
 
     bucket = 'juliabox-user-home-templates'
 
     VolMgr.log_debug("pushing new image files to s3 at: %s", bucket)
-    CloudHost.push_file_to_s3(bucket, new_img_file)
-    CloudHost.push_file_to_s3(bucket, new_pkg_file)
+    CloudHost.push_file_to_s3(bucket, imgf)
+    CloudHost.push_file_to_s3(bucket, pkgf)
 
     # JuliaBoxTest JuliaBox
     clusters = sys.argv[1] if (len(sys.argv) > 1) else ['JuliaBoxTest']
 
     for cluster in clusters:
         VolMgr.log_debug("setting image for cluster: %s", cluster)
-        JBoxDynConfig.set_user_home_image(cluster, bucket, new_pkg_file_name, new_img_file_name)
+        JBoxDynConfig.set_user_home_image(cluster, bucket, pkgf, imgf)

--- a/scripts/run/clean.sh
+++ b/scripts/run/clean.sh
@@ -2,12 +2,12 @@
 # Clean all logs
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-JBOX_DIR=`readlink -e ${DIR}/../..`
+source ${DIR}/../jboxcommon.sh
 
-\rm -f ${JBOX_DIR}/host/run/*.log
-\rm -f ${JBOX_DIR}/webserver/logs/*.log
-\rm -f ${JBOX_DIR}/engine/logs/*.log
+\rm -f ${HOST_DIR}/run/*.log
+\rm -f ${WEBSERVER_DIR}/logs/*.log
+\rm -f ${ENGINE_DIR}/logs/*.log
 
-\rm -f ${JBOX_DIR}/host/run/*.log.?
-\rm -f ${JBOX_DIR}/webserver/logs/*.log.?
-\rm -f ${JBOX_DIR}/engine/logs/*.log.?
+\rm -f ${HOST_DIR}/run/*.log.?
+\rm -f ${WEBSERVER_DIR}/logs/*.log.?
+\rm -f ${ENGINE_DIR}/logs/*.log.?

--- a/scripts/run/docker_rmall.sh
+++ b/scripts/run/docker_rmall.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-for id in `docker ps -a | cut -d" " -f1 | grep -v CONTAINER`; do echo "removing $id..."; docker kill $id; docker rm $id; done
+
+echo "killing all containers..."
+docker kill $(docker ps -a -q)
+
+echo "removing stopped containers..."
+docker rm $(docker ps -a -q)
+
+echo "removing untagged images..."
+docker rmi $(docker images | grep "^<none>" | awk '{print $3}')

--- a/scripts/run/reload.sh
+++ b/scripts/run/reload.sh
@@ -2,6 +2,6 @@
 # Restart JuliaBox server
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-JBOX_DIR=`readlink -e ${DIR}/../..`
+source ${DIR}/../jboxcommon.sh
 
-sudo supervisorctl -c ${PWD}/host/supervisord.conf restart all
+sudo supervisorctl -c ${HOST_DIR}/supervisord.conf restart all

--- a/scripts/run/start.sh
+++ b/scripts/run/start.sh
@@ -2,7 +2,7 @@
 # Start JuliaBox server
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-JBOX_DIR=`readlink -e ${DIR}/../..`
+source ${DIR}/../jboxcommon.sh
 
-sudo supervisord -c ${JBOX_DIR}/host/supervisord.conf
-sudo supervisorctl -c ${JBOX_DIR}/host/supervisord.conf start all
+sudo supervisord -c ${HOST_DIR}/supervisord.conf
+sudo supervisorctl -c ${HOST_DIR}/supervisord.conf start all

--- a/scripts/run/stop.sh
+++ b/scripts/run/stop.sh
@@ -2,7 +2,7 @@
 # Stop JuliaBox server
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-JBOX_DIR=`readlink -e ${DIR}/../..`
+source ${DIR}/../jboxcommon.sh
 
-sudo supervisorctl -c ${JBOX_DIR}/host/supervisord.conf stop all
-sudo supervisorctl -c ${JBOX_DIR}/host/supervisord.conf shutdown
+sudo supervisorctl -c ${HOST_DIR}/supervisord.conf stop all
+sudo supervisorctl -c ${HOST_DIR}/supervisord.conf shutdown

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -60,8 +60,7 @@ ADD www /jboxweb/www
 ADD scripts/router.lua /jboxweb/openresty/lualib/juliabox/
 
 RUN ln -fs /usr/share/lua /usr/local/share/lua \
-    && ln -fs /usr/lib/x86_64-linux-gnu/lua /usr/local/lib/lua \
-    && cp /jboxweb/conf/logrotate.conf /etc/logrotate.d/jboxweb_logrotate.conf
+    && ln -fs /usr/lib/x86_64-linux-gnu/lua /usr/local/lib/lua
 
 # Run nginx in foreground (daemon set to off in configuration)
 ENTRYPOINT ["/jboxweb/openresty/nginx/sbin/nginx", "-p", "/jboxweb"]


### PR DESCRIPTION
This fixes EBS volumes broken by #249 by enabling mounting of EBS volumes on host from within a container. The engine daemon prefixes commands related to the `Mount` namespaces with a configurable prefix. The prefix command uses `nsenter` to execute the mount commands in the `mount` namespace of the host init process.

Also simplified scripts used for installation and running, and added helper scripts for managing installation on AWS.