### PR TITLE
mount EBS volumes as data volumes, not as user home

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,9 @@ RUN mkdir /opt/julia_packages
 RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.4/")' >> /opt/julia_0.4.0/etc/julia/juliarc.jl
 RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/")' >> /opt/julia_0.3.10/etc/julia/juliarc.jl
 
+# Data volumes shall be mounted at /mnt/data
+RUN mkdir /mnt/data
+
 USER juser
 ENV HOME /home/juser
 ENV PATH /usr/local/texlive/2014/bin/x86_64-linux:/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin:/opt/julia/bin

--- a/engine/Dockerfile.daemon
+++ b/engine/Dockerfile.daemon
@@ -25,6 +25,7 @@ RUN echo "juser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Provide env with command prefix required to access host mnt namespace
 ENV HOST_MNT_PFX="nsenter --target 1 --proc /hostproc --mnt --" \
+    CONT_MNT_PFX="nsenter --target {{CPID}} --proc /hostproc --mnt --" \
     HOST_IPC_PFX="nsenter --target 1 --proc /hostproc --ipc --"
 
 USER juser

--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -56,7 +56,6 @@
     	"cloudwatch": True,
     	"autoscale": True,
     	"route53": True,
-    	"ebs": True,
         "ses": True,
 
     	"autoscale_group": "juliabox",
@@ -73,7 +72,6 @@
 
 	    # EBS disk template snapshot id
 	    "ebs_template": None,
-	    "ebs_mnt_location": "/jboxengine/data/disks/ebs",
 
     	"dummy" : "dummy"
     },

--- a/engine/src/juliabox/cloud/awsebsvol.py
+++ b/engine/src/juliabox/cloud/awsebsvol.py
@@ -1,13 +1,14 @@
 __author__ = 'tan'
-import datetime
+# import datetime
 import time
 import os
-import sh
-#import stat
-import pytz
+# import sh
+# import stat
+# import pytz
 
 from juliabox.cloud.aws import CloudHost
-from juliabox.jbox_util import retry, parse_iso_time, create_host_mnt_command
+from juliabox.jbox_util import retry, create_host_mnt_command
+# from juliabox.jbox_util import parse_iso_time
 
 
 class EBSVol(CloudHost):
@@ -33,28 +34,28 @@ class EBSVol(CloudHost):
         if EBSVol.SH_UMOUNT is None:
             EBSVol.SH_UMOUNT = create_host_mnt_command("umount")
 
-    @staticmethod
-    def _mount_device(dev_id, mount_dir):
-        EBSVol.configure_host_commands()
-        t1 = time.time()
-        device = os.path.join('/dev', dev_id)
-        mount_point = os.path.join(mount_dir, dev_id)
-        actual_mount_point = EBSVol._get_mount_point(dev_id)
-        if actual_mount_point == mount_point:
-            EBSVol.log_debug("Device %s already mounted at %s", device, mount_point)
-            return
-        elif actual_mount_point is None:
-            EBSVol.log_debug("Mounting device %s at %s", device, mount_point)
-            res = EBSVol.SH_MOUNT(mount_point)  # the mount point must be mentioned in fstab file
-            if res.exit_code != 0:
-                raise Exception("Failed to mount device %s at %s. Error code: %d", device, mount_point, res.exit_code)
-        else:
-            raise Exception("Device already mounted at " + actual_mount_point)
-        tdiff = int(time.time() - t1)
-        EBSVol.publish_stats("EBSMountTime", "Count", tdiff)
+    # @staticmethod
+    # def _mount_device(dev_id, mount_dir):
+    #     EBSVol.configure_host_commands()
+    #     t1 = time.time()
+    #     device = os.path.join('/dev', dev_id)
+    #     mount_point = os.path.join(mount_dir, dev_id)
+    #     actual_mount_point = EBSVol._get_mount_point(dev_id)
+    #     if actual_mount_point == mount_point:
+    #         EBSVol.log_debug("Device %s already mounted at %s", device, mount_point)
+    #         return
+    #     elif actual_mount_point is None:
+    #         EBSVol.log_debug("Mounting device %s at %s", device, mount_point)
+    #         res = EBSVol.SH_MOUNT(mount_point)  # the mount point must be mentioned in fstab file
+    #         if res.exit_code != 0:
+    #             raise Exception("Failed to mount device %s at %s. Error code: %d", device, mount_point, res.exit_code)
+    #     else:
+    #         raise Exception("Device already mounted at " + actual_mount_point)
+    #     tdiff = int(time.time() - t1)
+    #     EBSVol.publish_stats("EBSMountTime", "Count", tdiff)
 
     @staticmethod
-    def _get_volume(vol_id):
+    def get_volume(vol_id):
         vols = CloudHost.connect_ec2().get_all_volumes([vol_id])
         if len(vols) == 0:
             return None
@@ -62,38 +63,38 @@ class EBSVol(CloudHost):
 
     @staticmethod
     def _get_volume_attach_info(vol_id):
-        vol = EBSVol._get_volume(vol_id)
+        vol = EBSVol.get_volume(vol_id)
         if vol is None:
             return None, None
         att = vol.attach_data
         return att.instance_id, att.device
 
-    @staticmethod
-    def unmount_device(dev_id, mount_dir):
-        EBSVol.configure_host_commands()
-        mount_point = os.path.join(mount_dir, dev_id)
-        actual_mount_point = EBSVol._get_mount_point(dev_id)
-        if actual_mount_point is None:
-            return  # not mounted
-        t1 = time.time()
-        if mount_point != actual_mount_point:
-            EBSVol.log_warn("Mount point expected: %s, actual: %r. Taking actual.", mount_point, actual_mount_point)
-            mount_point = actual_mount_point
-        EBSVol.log_debug("Unmounting dev_id: %r from %r", dev_id, mount_point)
-        res = EBSVol.SH_UMOUNT(mount_point)  # the mount point must be mentioned in fstab file
-        if res.exit_code != 0:
-            raise Exception("Device could not be unmounted from " + mount_point)
-        tdiff = int(time.time() - t1)
-        EBSVol.publish_stats("EBSUnmountTime", "Count", tdiff)
+    # @staticmethod
+    # def unmount_device(dev_id, mount_dir):
+    #     EBSVol.configure_host_commands()
+    #     mount_point = os.path.join(mount_dir, dev_id)
+    #     actual_mount_point = EBSVol._get_mount_point(dev_id)
+    #     if actual_mount_point is None:
+    #         return  # not mounted
+    #     t1 = time.time()
+    #     if mount_point != actual_mount_point:
+    #         EBSVol.log_warn("Mount point expected: %s, actual: %r. Taking actual.", mount_point, actual_mount_point)
+    #         mount_point = actual_mount_point
+    #     EBSVol.log_debug("Unmounting dev_id: %r from %r", dev_id, mount_point)
+    #     res = EBSVol.SH_UMOUNT(mount_point)  # the mount point must be mentioned in fstab file
+    #     if res.exit_code != 0:
+    #         raise Exception("Device could not be unmounted from " + mount_point)
+    #     tdiff = int(time.time() - t1)
+    #     EBSVol.publish_stats("EBSUnmountTime", "Count", tdiff)
 
-    @staticmethod
-    def _get_mount_point(dev_id):
-        EBSVol.configure_host_commands()
-        device = os.path.join('/dev', dev_id)
-        for line in EBSVol.SH_MOUNT():
-            if line.startswith(device):
-                return line.split()[2]
-        return None
+    # @staticmethod
+    # def _get_mount_point(dev_id):
+    #     EBSVol.configure_host_commands()
+    #     device = os.path.join('/dev', dev_id)
+    #     for line in EBSVol.SH_MOUNT():
+    #         if line.startswith(device):
+    #             return line.split()[2]
+    #     return None
 
     @staticmethod
     def _device_exists(dev):
@@ -104,7 +105,7 @@ class EBSVol(CloudHost):
             # use stat instead?
             return len(line) > 0 and line[0] == 'b'
         except:
-            EBSVol.log_exception("Exception waiting for device state")
+            # EBSVol.log_exception("Exception waiting for device state")
             return False
 
     # @staticmethod
@@ -116,14 +117,14 @@ class EBSVol(CloudHost):
     #     return stat.S_ISBLK(mode)
 
     @staticmethod
-    @retry(10, 0.5, backoff=1.5)
+    @retry(6, 1, backoff=2)
     def _wait_for_device(dev):
         return EBSVol._device_exists(dev)
 
     @staticmethod
     def _ensure_volume_available(vol_id, force_detach=False):
         conn = CloudHost.connect_ec2()
-        vol = EBSVol._get_volume(vol_id)
+        vol = EBSVol.get_volume(vol_id)
         if vol is None:
             raise Exception("Volume not found: " + vol_id)
 
@@ -148,12 +149,11 @@ class EBSVol(CloudHost):
                             ", state: " + vol.status)
 
     @staticmethod
-    def _attach_free_volume(vol_id, dev_id, mount_dir):
+    def _attach_free_volume(vol_id, dev_id):
         conn = CloudHost.connect_ec2()
         instance_id = CloudHost.instance_id()
         device = os.path.join('/dev', dev_id)
-        mount_point = os.path.join(mount_dir, dev_id)
-        vol = EBSVol._get_volume(vol_id)
+        vol = EBSVol.get_volume(vol_id)
 
         EBSVol.log_info("Attaching volume %s at %s", vol_id, device)
         t1 = time.time()
@@ -169,11 +169,10 @@ class EBSVol(CloudHost):
         tdiff = int(time.time() - t1)
         CloudHost.publish_stats("EBSAttachTime", "Count", tdiff)
 
-        EBSVol._mount_device(dev_id, mount_dir)
-        return device, mount_point
+        return device
 
     @staticmethod
-    def _get_mapped_volumes(instance_id=None):
+    def get_mapped_volumes(instance_id=None):
         if instance_id is None:
             instance_id = CloudHost.instance_id()
 
@@ -183,7 +182,7 @@ class EBSVol(CloudHost):
     @staticmethod
     def get_volume_id_from_device(dev_id):
         device = os.path.join('/dev', dev_id)
-        maps = EBSVol._get_mapped_volumes()
+        maps = EBSVol.get_mapped_volumes()
         EBSVol.log_debug("Devices mapped: %r", maps)
         if device not in maps:
             return None
@@ -197,21 +196,21 @@ class EBSVol(CloudHost):
         snap = snaps[0]
         return snap.status == 'completed'
 
-    @staticmethod
-    def get_snapshot_age(snap_id):
-        snaps = CloudHost.connect_ec2().get_all_snapshots([snap_id])
-        if len(snaps) == 0:
-            raise Exception("Snapshot not found with id " + str(snap_id))
-        snap = snaps[0]
+    # @staticmethod
+    # def get_snapshot_age(snap_id):
+    #     snaps = CloudHost.connect_ec2().get_all_snapshots([snap_id])
+    #     if len(snaps) == 0:
+    #         raise Exception("Snapshot not found with id " + str(snap_id))
+    #     snap = snaps[0]
+    #
+    #     st = parse_iso_time(snap.start_time)
+    #     nt = datetime.datetime.now(pytz.utc)
+    #     return nt - st
 
-        st = parse_iso_time(snap.start_time)
-        nt = datetime.datetime.now(pytz.utc)
-        return nt - st
-
     @staticmethod
-    def create_new_volume(snap_id, dev_id, mount_dir, tag=None, disk_sz_gb=1):
+    def create_new_volume(snap_id, dev_id, tag=None, disk_sz_gb=1):
         EBSVol.configure_host_commands()
-        EBSVol.log_info("Creating volume. Tag: %s, Snapshot: %s. Mounted: %s, %s", tag, snap_id, dev_id, mount_dir)
+        EBSVol.log_info("Creating volume. Tag: %s, Snapshot: %s. Attached: %s", tag, snap_id, dev_id)
         conn = CloudHost.connect_ec2()
         vol = conn.create_volume(disk_sz_gb, CloudHost.zone(),
                                  snapshot=snap_id,
@@ -226,8 +225,8 @@ class EBSVol(CloudHost):
             conn.create_tags([vol_id], {"Name": tag})
             EBSVol.log_info("Added tag %s to volume with id %s", tag, vol_id)
 
-        mnt_info = EBSVol._attach_free_volume(vol_id, dev_id, mount_dir)
-        return mnt_info[0], mnt_info[1], vol_id
+        device_path = EBSVol._attach_free_volume(vol_id, dev_id)
+        return device_path, vol_id
 
     # @staticmethod
     # def detach_mounted_volume(dev_id, mount_dir, delete=False):
@@ -256,7 +255,7 @@ class EBSVol(CloudHost):
         conn = CloudHost.connect_ec2()
         if instance is not None:  # the volume is attached
             EBSVol.log_debug("Detaching %s from instance %s device %r", vol_id, instance, device)
-            vol = EBSVol._get_volume(vol_id)
+            vol = EBSVol.get_volume(vol_id)
             t1 = time.time()
             conn.detach_volume(vol_id, instance, device)
             if not CloudHost._wait_for_status_extended(vol, 'available'):
@@ -268,35 +267,28 @@ class EBSVol(CloudHost):
             conn.delete_volume(vol_id)
 
     @staticmethod
-    def attach_volume(vol_id, dev_id, mount_dir, force_detach=False):
+    def attach_volume(vol_id, dev_id, force_detach=False):
         """
-        In order for EBS volumes to be mountable on the host system, JuliaBox relies on the fstab file must have
-        pre-filled mount points with options to allow non-root user to mount/unmount them. This necesseciates that
-        the mount point and device ids association be fixed beforehand. So we follow a convention where /dev/dev_id
-        will be mounted at /mount_dir/dev_id
+        Returns the device path where the volume is attached.
 
-        Returns the device path and mount path where the volume was attached.
-
-        If the volume is already mounted on the current instance, the existing device and mount paths are returned,
+        If the volume is already attached to the current instance, the existing device path is returned,
         which may be different from what was requested.
 
-        :param vol_id: EBS volume id to mount
+        :param vol_id: EBS volume id to attach
         :param dev_id: volume will be attached at /dev/dev_id
-        :param mount_dir: device will be mounted at /mount_dir/dev_id
         :param force_detach: detach the volume from any other instance that might have attached it
-        :return: device_path, mount_path
+        :return: device_path
         """
         EBSVol.configure_host_commands()
-        EBSVol.log_info("Attaching volume %s to dev_id %s at %s", vol_id, dev_id, mount_dir)
+        EBSVol.log_info("Attaching volume %s to dev_id %s", vol_id, dev_id)
         EBSVol._ensure_volume_available(vol_id, force_detach=force_detach)
         att_instance_id, att_device = EBSVol._get_volume_attach_info(vol_id)
 
         if att_instance_id is None:
-            return EBSVol._attach_free_volume(vol_id, dev_id, mount_dir)
+            return EBSVol._attach_free_volume(vol_id, dev_id)
         else:
             EBSVol.log_warn("Volume %s already attached to %s at %s", vol_id, att_instance_id, att_device)
-            EBSVol._mount_device(dev_id, mount_dir)
-            return att_device, os.path.join(mount_dir, dev_id)
+            return att_device
 
     @staticmethod
     def snapshot_volume(vol_id=None, dev_id=None, tag=None, description=None, wait_till_complete=True):
@@ -306,7 +298,7 @@ class EBSVol(CloudHost):
         if vol_id is None:
             EBSVol.log_warn("No volume to snapshot. vol_id: %r, dev_id %r", vol_id, dev_id)
             return
-        vol = EBSVol._get_volume(vol_id)
+        vol = EBSVol.get_volume(vol_id)
         EBSVol.log_info("Creating snapshot for volume: %s", vol_id)
         snap = vol.create_snapshot(description)
         if wait_till_complete and (not CloudHost._wait_for_status_extended(snap, 'completed')):

--- a/engine/src/juliabox/db/user_v2.py
+++ b/engine/src/juliabox/db/user_v2.py
@@ -74,7 +74,7 @@ class JBoxUserV2(JBoxDB):
     ACTIVATION_CODE_AUTO = 'AUTO'
     
     RES_PROF_BASIC = 0
-    RES_PROF_DISK_EBS_1G = 1 << 0
+    RES_PROF_DISK_EBS_10G = 1 << 0
 
     RES_PROF_JULIA_PKG_PRECOMP = 1 << 12
     RES_PROF_CLUSTER = 1 << 13
@@ -327,8 +327,8 @@ class JBoxUserV2(JBoxDB):
         if res_profile_val == JBoxUserV2.RES_PROF_BASIC:
             res_profile['basic'] += 1
         else:
-            if (res_profile_val & JBoxUserV2.RES_PROF_DISK_EBS_1G) == JBoxUserV2.RES_PROF_DISK_EBS_1G:
-                res_profile['disk_ebs_1G'] += 1
+            if (res_profile_val & JBoxUserV2.RES_PROF_DISK_EBS_10G) == JBoxUserV2.RES_PROF_DISK_EBS_10G:
+                res_profile['disk_ebs_10G'] += 1
             elif (res_profile_val & JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP) == JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP:
                 res_profile['julia_packages_precompiled'] += 1
             elif (res_profile_val & JBoxUserV2.RES_PROF_CLUSTER) == JBoxUserV2.RES_PROF_CLUSTER:

--- a/engine/src/juliabox/handlers/main.py
+++ b/engine/src/juliabox/handlers/main.py
@@ -97,6 +97,9 @@ class MainHandler(JBoxHandler):
                            js_includes=JBoxHandlerPlugin.PLUGIN_JAVASCRIPTS)
 
     def chk_and_launch_docker(self, user_id):
+        if self.redirect_to_logged_in_instance(user_id):
+            return
+
         nhops = int(self.get_argument('h', 0))
         numhopmax = JBoxCfg.get('numhopmax', 0)
         max_hop = nhops > numhopmax

--- a/engine/src/juliabox/jbox_container.py
+++ b/engine/src/juliabox/jbox_container.py
@@ -428,7 +428,7 @@ class JBoxContainer(LoggerMixin):
         if self.is_running() or self.is_restarting():
             self.kill()
 
-        for disktype in (JBoxVol.PLUGIN_USERHOME, JBoxVol.PLUGIN_PKGBUNDLE):
+        for disktype in (JBoxVol.PLUGIN_USERHOME, JBoxVol.PLUGIN_PKGBUNDLE, JBoxVol.PLUGIN_DATA):
             disk = VolMgr.get_disk_from_container(self.dockid, disktype)
             if disk is not None:
                 disk.release(backup=backup)

--- a/engine/src/juliabox/jbox_tasks.py
+++ b/engine/src/juliabox/jbox_tasks.py
@@ -88,7 +88,7 @@ class JBoxAsyncJob(LoggerMixin):
 
     def sendrecv(self, cmd, data, dest=None, port=None):
         if (dest is None) or (dest == 'localhost'):
-            dest = '127.0.0.1'
+            dest = CloudHost.instance_local_ip()
         else:
             dest = CloudHost.instance_local_ip(dest)
         if port is None:
@@ -179,7 +179,7 @@ class JBoxAsyncJob(LoggerMixin):
 
     @staticmethod
     def sync_session_status(instance_id):
-        JBoxAsyncJob.log_debug("fetching session status from %s", instance_id)
+        JBoxAsyncJob.log_debug("fetching session status from %r", instance_id)
         return JBoxAsyncJob.get().sendrecv(JBoxAsyncJob.CMD_SESSION_STATUS, {}, dest=instance_id)
 
     @staticmethod

--- a/engine/src/juliabox/jbox_tasks.py
+++ b/engine/src/juliabox/jbox_tasks.py
@@ -17,6 +17,7 @@ class JBoxAsyncJob(LoggerMixin):
     CMD_REFRESH_DISKS = 5
     CMD_COLLECT_STATS = 6
     CMD_PLUGIN_MAINTENANCE = 9
+    CMD_PLUGIN_TASK = 10
 
     CMD_REQ_RESP = 50
     CMD_SESSION_STATUS = 51
@@ -185,6 +186,26 @@ class JBoxAsyncJob(LoggerMixin):
     def async_plugin_maintenance(is_leader):
         JBoxAsyncJob.log_info("scheduling plugin maintenance. leader:%r", is_leader)
         JBoxAsyncJob.get().send(JBoxAsyncJob.CMD_PLUGIN_MAINTENANCE, is_leader)
+
+    @staticmethod
+    def async_plugin_task(target_class, data):
+        JBoxAsyncJob.log_info("invoking plugin task. target_class:%s", target_class)
+        JBoxAsyncJob.get().send(JBoxAsyncJob.CMD_PLUGIN_TASK, (JBoxdPlugin.PLUGIN_CMD, target_class, data))
+
+
+class JBoxdPlugin(LoggerMixin):
+    """ Base class for plugins providing asynchronous tasks.
+
+    It is a plugin mount point, looking for features:
+    - async_task
+
+    Methods expected:
+    - do_task: invoked with plugin class name, feature in context, and data as argument
+    """
+
+    __metaclass__ = JBoxPluginType
+
+    PLUGIN_CMD = 'async_cmd'
 
 
 class JBoxHousekeepingPlugin(LoggerMixin):

--- a/engine/src/juliabox/jbox_util.py
+++ b/engine/src/juliabox/jbox_util.py
@@ -47,6 +47,10 @@ def retry(tries, delay=1, backoff=2):
 
                 mtries -= 1      # consume an attempt
                 time.sleep(mdelay)  # wait...
+                # tend = time.time() + mdelay
+                # while time.time() < tend:
+                #     LoggerMixin.log_debug("sleeping...")
+                #     time.sleep(tend - time.time())  # wait...
                 mdelay *= backoff  # make future wait longer
 
                 rv = f(*args, **kwargs)  # Try again
@@ -129,6 +133,17 @@ def unquote(s):
 def create_host_mnt_command(cmd):
     pfx = os.getenv('HOST_MNT_PFX')
     if pfx:
+        cmd = pfx + " " + cmd
+    hcmd = sh.sudo
+    for comp in cmd.split():
+        hcmd = hcmd.bake(comp)
+    return hcmd
+
+
+def create_container_mnt_command(container_pid, cmd):
+    pfx = os.getenv('CONT_MNT_PFX')
+    if pfx:
+        pfx = pfx.replace('{{CPID}}', str(container_pid))
         cmd = pfx + " " + cmd
     hcmd = sh.sudo
     for comp in cmd.split():

--- a/engine/src/juliabox/plugins/vol_defpkg/defpkg.py
+++ b/engine/src/juliabox/plugins/vol_defpkg/defpkg.py
@@ -6,6 +6,7 @@ from juliabox.jbox_util import ensure_delete, make_sure_path_exists, JBoxCfg
 from juliabox.vol import JBoxVol
 from juliabox.jbox_container import JBoxContainer
 
+
 class JBoxDefaultPackagesVol(JBoxVol):
     provides = [JBoxVol.PLUGIN_PKGBUNDLE]
 

--- a/engine/src/juliabox/plugins/vol_ebs/__init__.py
+++ b/engine/src/juliabox/plugins/vol_ebs/__init__.py
@@ -2,3 +2,4 @@ __author__ = 'tan'
 from ebs import JBoxEBSVol
 from disk_state_tbl import JBoxDiskState
 from ebs_housekeep import JBoxEBSHousekeep
+from ebs_handler import JBoxEBSVolAsyncTask, JBoxEBSVolUIModule, JBoxEBSVolHandler

--- a/engine/src/juliabox/plugins/vol_ebs/disk_state_tbl.py
+++ b/engine/src/juliabox/plugins/vol_ebs/disk_state_tbl.py
@@ -28,6 +28,8 @@ class JBoxDiskState(JBoxDBPlugin):
     TABLE = None
 
     STATE_ATTACHED = 1
+    STATE_ATTACHING = 2
+    STATE_DETACHING = 3
     STATE_DETACHED = 0
 
     def __init__(self, disk_key=None, cluster_id=None, region_id=None, user_id=None, volume_id=None,
@@ -81,10 +83,15 @@ class JBoxDiskState(JBoxDBPlugin):
         return JBoxDiskState.epoch_secs_to_datetime(int(self.item['detach_time']))
 
     def get_state(self):
-        return self.get_attrib('state')
+        state = self.get_attrib('state')
+        return int(state) if state is not None else None
 
-    def set_state(self, state):
+    def set_state(self, state, time=None):
         self.set_attrib('state', state)
+        if state == JBoxDiskState.STATE_ATTACHING or state == JBoxDiskState.STATE_ATTACHED:
+            self.set_attach_time(time)
+        else:
+            self.set_detach_time(time)
 
     def get_user_id(self):
         return self.get_attrib('user_id')

--- a/engine/src/juliabox/plugins/vol_ebs/ebs.py
+++ b/engine/src/juliabox/plugins/vol_ebs/ebs.py
@@ -25,7 +25,7 @@ class JBoxEBSVol(JBoxVol):
     @staticmethod
     def configure():
         num_disks_max = JBoxCfg.get('numdisksmax')
-        JBoxEBSVol.DISK_LIMIT = 1
+        JBoxEBSVol.DISK_LIMIT = 10
         JBoxEBSVol.MAX_DISKS = num_disks_max
         JBoxEBSVol.DISK_TEMPLATE_SNAPSHOT = JBoxCfg.get('cloud_host.ebs_template')
 

--- a/engine/src/juliabox/plugins/vol_ebs/ebs.py
+++ b/engine/src/juliabox/plugins/vol_ebs/ebs.py
@@ -1,50 +1,36 @@
 import os
 import threading
 import time
-#import sh
 from string import ascii_lowercase
 
 from juliabox.cloud.awsebsvol import EBSVol
 from juliabox.cloud.aws import CloudHost
 from juliabox.db import JBoxSessionProps
 from juliabox.jbox_util import unique_sessname, JBoxCfg
-# from juliabox.jbox_util import create_host_mnt_command
 from juliabox.vol import JBoxVol
 from disk_state_tbl import JBoxDiskState
-from juliabox.jbox_container import JBoxContainer
 
 
 class JBoxEBSVol(JBoxVol):
-    provides = [JBoxVol.PLUGIN_USERHOME, JBoxVol.PLUGIN_EBS_USERHOME]
+    provides = [JBoxVol.PLUGIN_EBS_DATA, JBoxVol.PLUGIN_DATA]
 
     DEVICES = []
     MAX_DISKS = 0
-    FS_LOC = None
     DISK_LIMIT = None
     DISK_USE_STATUS = {}
     DISK_RESERVE_TIME = {}
     DISK_TEMPLATE_SNAPSHOT = None
     LOCK = None
-    # SH_READ_FSTAB = None
 
     @staticmethod
     def configure():
-        # JBoxEBSVol.SH_READ_FSTAB = create_host_mnt_command("cat /etc/fstab")
         num_disks_max = JBoxCfg.get('numdisksmax')
-        JBoxEBSVol.FS_LOC = os.path.expanduser(JBoxCfg.get('cloud_host.ebs_mnt_location'))
         JBoxEBSVol.DISK_LIMIT = 1
         JBoxEBSVol.MAX_DISKS = num_disks_max
         JBoxEBSVol.DISK_TEMPLATE_SNAPSHOT = JBoxCfg.get('cloud_host.ebs_template')
 
         JBoxEBSVol.DEVICES = JBoxEBSVol._guess_configured_devices('xvd', num_disks_max)
         JBoxEBSVol.log_debug("Assuming %d EBS volumes configured in range xvdba..xvdcz", len(JBoxEBSVol.DEVICES))
-        # JBoxEBSVol.DEVICES = JBoxEBSVol._get_configured_devices(JBoxEBSVol.FS_LOC)
-        # if len(JBoxEBSVol.DEVICES) < num_disks_max:
-        #     JBoxEBSVol.log_error("Not enough EBS mount points configured. Found %d, configured %d",
-        #                          len(JBoxEBSVol.DEVICES), num_disks_max)
-        #     raise Exception("Not enough EBS mount points configured")
-        # else:
-        #     JBoxEBSVol.log_debug("Found %d EBS volumes configured", len(JBoxEBSVol.DEVICES))
 
         JBoxEBSVol.LOCK = threading.Lock()
         JBoxEBSVol.refresh_disk_use_status()
@@ -52,23 +38,6 @@ class JBoxEBSVol(JBoxVol):
     @classmethod
     def get_disk_allocated_size(cls):
         return JBoxEBSVol.DISK_LIMIT * 1000000000
-
-    # @staticmethod
-    # def _id_from_device(dev_path):
-    #     return dev_path.split('/')[-1]
-    #
-    # @staticmethod
-    # def _get_configured_devices(fs_loc):
-    #     devices = []
-    #     for line in JBoxEBSVol.SH_READ_FSTAB():
-    #         line = line.strip()
-    #         if (len(line) == 0) or line.startswith('#'):
-    #             continue
-    #         comps = line.split()
-    #         if (len(comps) == 6) and comps[1].startswith(fs_loc):
-    #             device = comps[0]
-    #             devices.append(JBoxEBSVol._id_from_device(device))
-    #     return devices
 
     @staticmethod
     def _guess_configured_devices(devidpfx, num_disks):
@@ -81,25 +50,8 @@ class JBoxEBSVol(JBoxVol):
         return devices
 
     @staticmethod
-    def _get_disk_ids_used(cid):
-        used = []
-        props = JBoxEBSVol.dckr().inspect_container(cid)
-        try:
-            vols = props['Volumes']
-            for _cpath, hpath in vols.iteritems():
-                if hpath.startswith(JBoxEBSVol.FS_LOC):
-                    used.append(hpath.split('/')[-1])
-        except:
-            JBoxEBSVol.log_error("error finding disk ids used in " + cid)
-            return []
-        return used
-
-    @staticmethod
-    def refresh_user_home_image():
-        pass
-
-    @staticmethod
     def refresh_disk_use_status(container_id_list=None):
+        JBoxEBSVol.log_debug("Refrshing EBS disk use status")
         JBoxEBSVol.LOCK.acquire()
         try:
             nfree = 0
@@ -111,17 +63,20 @@ class JBoxEBSVol(JBoxVol):
                     JBoxEBSVol.DISK_USE_STATUS[dev] = False
                     nfree += 1
 
-            if container_id_list is None:
-                container_id_list = [cdesc['Id'] for cdesc in JBoxContainer.session_containers(allcontainers=True)]
-
-            for cid in container_id_list:
-                disk_ids = JBoxEBSVol._get_disk_ids_used(cid)
-                for disk_id in disk_ids:
-                    JBoxEBSVol._mark_disk_used(disk_id)
-                    nfree -= 1
-            JBoxEBSVol.log_info("Disk free: " + str(nfree) + "/" + str(JBoxEBSVol.MAX_DISKS))
+            for device, volume in JBoxEBSVol.get_mapped_volumes().iteritems():
+                JBoxEBSVol.DISK_USE_STATUS[os.path.basename(device)] = True
+                nfree -= 1
+            JBoxEBSVol.log_info("EBS Disk free: " + str(nfree) + "/" + str(JBoxEBSVol.MAX_DISKS))
+        except:
+            JBoxEBSVol.log_exception("Exception refrshing EBS disk use status")
         finally:
             JBoxEBSVol.LOCK.release()
+
+    @staticmethod
+    def get_mapped_volumes():
+        allmaps = EBSVol.get_mapped_volumes()
+        JBoxEBSVol.log_debug("Devices mapped: %r", allmaps)
+        return dict((d,v) for d, v in allmaps.iteritems() if os.path.basename(d) in JBoxEBSVol.DEVICES)
 
     @staticmethod
     def _get_unused_disk_id():
@@ -157,6 +112,11 @@ class JBoxEBSVol(JBoxVol):
             JBoxEBSVol.LOCK.release()
 
     @staticmethod
+    def is_mount_path(fs_path):
+        # EBS volumes are not mounted on host
+        return False
+
+    @staticmethod
     def disk_ids_used_pct():
         pct = (sum(JBoxEBSVol.DISK_USE_STATUS.values()) * 100) / len(JBoxEBSVol.DISK_USE_STATUS)
         return min(100, max(0, pct))
@@ -187,69 +147,48 @@ class JBoxEBSVol(JBoxVol):
 
             JBoxEBSVol.log_debug("will use snapshot id %s for %s", snap_id, user_email)
 
-            _dev_path, mnt_path, vol_id = EBSVol.create_new_volume(snap_id, disk_id, JBoxEBSVol.FS_LOC,
-                                                                   tag=user_email, disk_sz_gb=JBoxEBSVol.DISK_LIMIT)
+            dev_path, vol_id = EBSVol.create_new_volume(snap_id, disk_id, tag=user_email,
+                                                        disk_sz_gb=JBoxEBSVol.DISK_LIMIT)
             existing_disk = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION,
                                           user_id=user_email,
                                           volume_id=vol_id,
                                           attach_time=None,
                                           create=True)
         else:
-            _dev_path, mnt_path = EBSVol.attach_volume(existing_disk.get_volume_id(), disk_id, JBoxEBSVol.FS_LOC)
-            existing_disk.set_attach_time()
-            snap_id = None
+            dev_path = EBSVol.attach_volume(existing_disk.get_volume_id(), disk_id)
 
-        existing_disk.set_state(JBoxDiskState.STATE_ATTACHED)
+        existing_disk.set_state(JBoxDiskState.STATE_ATTACHING)
         existing_disk.save()
 
-        ebsvol = JBoxEBSVol(mnt_path, user_email=user_email)
-
-        if snap_id == JBoxEBSVol.DISK_TEMPLATE_SNAPSHOT:
-            JBoxEBSVol.log_debug("creating home folder on blank volume for %s", user_email)
-            ebsvol.restore_user_home(True)
-            ebsvol.restore()
-        else:
-            JBoxEBSVol.log_debug("updating home folder on existing volume for %s", user_email)
-            ebsvol.restore_user_home(False)
-        #    snap_age_days = CloudHost.get_snapshot_age(snap_id).total_seconds()/(60*60*24)
-        #    if snap_age_days > 7:
-        #        ebsvol.restore_user_home()
-        JBoxEBSVol.log_debug("setting up instance configuration on disk for %s", user_email)
-        ebsvol.setup_instance_config()
-
-        return ebsvol
-
-    @staticmethod
-    def is_mount_path(fs_path):
-        return fs_path.startswith(JBoxEBSVol.FS_LOC)
+        return JBoxEBSVol(dev_path, user_email=user_email)
 
     @staticmethod
     def get_disk_from_container(cid):
-        disk_ids_used = JBoxEBSVol._get_disk_ids_used(cid)
-        if len(disk_ids_used) == 0:
-            return None
-
-        disk_id_used = disk_ids_used[0]
-        disk_path = os.path.join(JBoxEBSVol.FS_LOC, str(disk_id_used))
         container_name = JBoxVol.get_cname(cid)
         sessname = container_name[1:]
-        return JBoxEBSVol(disk_path, sessname=sessname)
+        for dev, vol in JBoxEBSVol.get_mapped_volumes().iteritems():
+            vol = EBSVol.get_volume(vol.volume_id)
+            if 'Name' in vol.tags:
+                name = vol.tags['Name']
+                if unique_sessname(name) == sessname:
+                    return JBoxEBSVol(dev, sessname=sessname)
+        return None
 
     def _backup(self, clear_volume=False):
         sess_props = JBoxSessionProps(self.sessname)
         desc = sess_props.get_user_id() + " JuliaBox Backup"
         disk_id = self.disk_path.split('/')[-1]
         snap_id = EBSVol.snapshot_volume(dev_id=disk_id, tag=self.sessname, description=desc, wait_till_complete=False)
-        # old_snap_id = sess_props.get_snapshot_id()
-        # sess_props.set_snapshot_id(snap_id)
-        # sess_props.save()
-        # if old_snap_id is not None:
-        #    CloudHost.delete_snapshot(old_snap_id)
         return snap_id
 
     def release(self, backup=False):
+        sess_props = JBoxSessionProps(self.sessname)
+        existing_disk = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION,
+                                      user_id=sess_props.get_user_id())
+        existing_disk.set_state(JBoxDiskState.STATE_DETACHING)
+        existing_disk.save()
+
         disk_id = self.disk_path.split('/')[-1]
-        EBSVol.unmount_device(disk_id, JBoxEBSVol.FS_LOC)
         if backup:
             snap_id = self._backup()
         else:
@@ -257,11 +196,8 @@ class JBoxEBSVol(JBoxVol):
         vol_id = EBSVol.get_volume_id_from_device(disk_id)
         EBSVol.detach_volume(vol_id, delete=False)
 
-        sess_props = JBoxSessionProps(self.sessname)
-        existing_disk = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION,
-                                      user_id=sess_props.get_user_id())
         if snap_id is not None:
             existing_disk.add_snapshot_id(snap_id)
-        existing_disk.set_detach_time()
+
         existing_disk.set_state(JBoxDiskState.STATE_DETACHED)
         existing_disk.save()

--- a/engine/src/juliabox/plugins/vol_ebs/ebs_handler.py
+++ b/engine/src/juliabox/plugins/vol_ebs/ebs_handler.py
@@ -24,7 +24,7 @@ class JBoxEBSVolAsyncTask(JBoxdPlugin):
         sessname = data['sessname']
 
         user = JBoxUserV2(user_id)
-        is_allowed = user.has_resource_profile(JBoxUserV2.RES_PROF_DISK_EBS_1G)
+        is_allowed = user.has_resource_profile(JBoxUserV2.RES_PROF_DISK_EBS_10G)
         if not is_allowed:
             JBoxEBSVolAsyncTask.log_error("Data volume access not allowed for user")
             return
@@ -89,7 +89,7 @@ class JBoxEBSVolUIModule(JBoxUIModulePlugin):
     def is_allowed(handler):
         user_id = JBoxEBSVolUIModule.get_user_id(handler)
         user = JBoxUserV2(user_id)
-        return user.has_resource_profile(JBoxUserV2.RES_PROF_DISK_EBS_1G)
+        return user.has_resource_profile(JBoxUserV2.RES_PROF_DISK_EBS_10G)
 
 
 class JBoxEBSVolHandler(JBoxHandlerPlugin):
@@ -153,6 +153,6 @@ class JBoxEBSVolHandler(JBoxHandlerPlugin):
 
         self.log_debug("EBS disk state: %r", state_code)
         return {
-            'disk_size': '1GB',
+            'disk_size': '10 GB',
             'state': state_code
         }

--- a/engine/src/juliabox/plugins/vol_ebs/ebs_handler.py
+++ b/engine/src/juliabox/plugins/vol_ebs/ebs_handler.py
@@ -1,0 +1,158 @@
+__author__ = 'tan'
+import os
+
+from juliabox.handlers import JBoxHandlerPlugin, JBoxUIModulePlugin
+from juliabox.jbox_tasks import JBoxdPlugin, JBoxAsyncJob
+from juliabox.jbox_container import JBoxContainer
+from juliabox.db import JBoxUserV2
+from juliabox.vol import JBoxVol
+from juliabox.cloud.aws import CloudHost
+
+from ebs import JBoxEBSVol
+from disk_state_tbl import JBoxDiskState
+
+
+class JBoxEBSVolAsyncTask(JBoxdPlugin):
+    provides = [JBoxdPlugin.PLUGIN_CMD]
+
+    @staticmethod
+    def do_task(plugin_name, plugin_type, data):
+        if plugin_name != JBoxEBSVolAsyncTask.__name__ or plugin_type != JBoxdPlugin.PLUGIN_CMD:
+            return
+        mode = data['action']
+        user_id = data['user_id']
+        sessname = data['sessname']
+
+        user = JBoxUserV2(user_id)
+        is_allowed = user.has_resource_profile(JBoxUserV2.RES_PROF_DISK_EBS_1G)
+        if not is_allowed:
+            JBoxEBSVolAsyncTask.log_error("Data volume access not allowed for user")
+            return
+
+        cont = JBoxContainer.get_by_name(sessname)
+        if cont is None:
+            return
+
+        vol = JBoxEBSVol.get_disk_from_container(sessname)
+        disk_state = None
+        try:
+            disk_state = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION, user_id=user_id)
+        except:
+            pass
+
+        JBoxEBSVolAsyncTask.log_debug("Data volume request %s for %s", mode, cont.debug_str())
+
+        if mode == 'attach':
+            if vol is None:
+                vol = JBoxEBSVol.get_disk_for_user(user_id)
+                JBoxEBSVol.mount_host_device(vol.disk_path, cont.dockid, JBoxVol.DATA_MOUNT_POINT)
+                disk_state = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION, user_id=user_id)
+                if disk_state.get_state() != JBoxDiskState.STATE_ATTACHED:
+                    disk_state.set_state(JBoxDiskState.STATE_ATTACHED)
+                    disk_state.save()
+        elif mode == 'detach':
+            if cont is not None and cont.is_running():
+                if vol is not None:
+                    # unmount from container first
+                    JBoxEBSVol.unmount_host_device(vol.disk_path, cont.dockid)
+                elif disk_state is not None:
+                    # no volume attached. ensure disk state is updated
+                    if disk_state.get_state() != JBoxDiskState.STATE_DETACHED:
+                        disk_state.set_state(JBoxDiskState.STATE_DETACHED)
+                        disk_state.save()
+            if vol is not None:
+                vol.release(backup=True)
+
+        JBoxEBSVolAsyncTask.log_debug("Data volume request %s completed for %s", mode, cont.debug_str())
+
+
+class JBoxEBSVolUIModule(JBoxUIModulePlugin):
+    provides = [JBoxUIModulePlugin.PLUGIN_CONFIG]
+    TEMPLATE_PATH = os.path.dirname(__file__)
+
+    @staticmethod
+    def get_template(plugin_type):
+        if plugin_type == JBoxUIModulePlugin.PLUGIN_CONFIG:
+            return os.path.join(JBoxEBSVolUIModule.TEMPLATE_PATH, "vol_ebs_html.tpl")
+        return None
+
+    @staticmethod
+    def get_user_id(handler):
+        sessname = handler.get_session_id()
+        user_id = handler.get_user_id()
+        if (sessname is None) or (user_id is None):
+            handler.send_error()
+            return
+        return user_id
+
+    @staticmethod
+    def is_allowed(handler):
+        user_id = JBoxEBSVolUIModule.get_user_id(handler)
+        user = JBoxUserV2(user_id)
+        return user.has_resource_profile(JBoxUserV2.RES_PROF_DISK_EBS_1G)
+
+
+class JBoxEBSVolHandler(JBoxHandlerPlugin):
+    provides = [JBoxHandlerPlugin.PLUGIN_HANDLER, JBoxHandlerPlugin.PLUGIN_JS]
+
+    @staticmethod
+    def get_js():
+        return "/assets/plugins/vol_ebs/vol_ebs.js"
+
+    @staticmethod
+    def register(app):
+        app.add_handlers(".*$", [(r"/jboxplugin/ebsdatavol/", JBoxEBSVolHandler)])
+
+    def get(self):
+        return self.post()
+
+    def post(self):
+        sessname = self.get_session_id()
+        user_id = self.get_user_id()
+        if (sessname is None) or (user_id is None):
+            self.send_error()
+            return
+
+        mode = self.get_argument('action', False)
+        if mode is False:
+            JBoxEBSVolHandler.log_error("Unknown mode for ebs handler")
+            self.send_error()
+            return
+
+        try:
+            if mode == 'attach' or mode == 'detach':
+                JBoxAsyncJob.async_plugin_task(JBoxEBSVolAsyncTask.__name__, {
+                    'action': mode,
+                    'user_id': user_id,
+                    'sessname': sessname
+                })
+                response = {'code': 0, 'data': ''}
+            elif mode == 'status':
+                response = {'code': 0, 'data': self._get_state(sessname, user_id)}
+            else:
+                response = {'code': -1, 'data': 'Unknown data volume operation ' + mode}
+        except Exception as ex:
+            JBoxEBSVolHandler.log_error("exception in data volume operation")
+            JBoxEBSVolHandler._get_logger().exception("exception in data volume operation")
+            response = {'code': -1, 'data': ex.message}
+
+        self.write(response)
+
+    def _get_state(self, sessname, user_id):
+        vol = JBoxEBSVol.get_disk_from_container(sessname)
+        state_code = JBoxDiskState.STATE_DETACHED
+        try:
+            disk_state = JBoxDiskState(cluster_id=CloudHost.INSTALL_ID, region_id=CloudHost.REGION, user_id=user_id)
+            state_code = disk_state.get_state()
+        except:
+            pass
+
+        if ((state_code == JBoxDiskState.STATE_ATTACHED) and (vol is None)) or \
+                ((state_code == JBoxDiskState.STATE_DETACHED) and (vol is not None)):
+            state_code = -1
+
+        self.log_debug("EBS disk state: %r", state_code)
+        return {
+            'disk_size': '1GB',
+            'state': state_code
+        }

--- a/engine/src/juliabox/plugins/vol_ebs/vol_ebs_html.tpl
+++ b/engine/src/juliabox/plugins/vol_ebs/vol_ebs_html.tpl
@@ -1,0 +1,111 @@
+{% from juliabox.plugins.vol_ebs import JBoxEBSVolUIModule %}
+<script type="text/javascript">
+{% if not JBoxEBSVolUIModule.is_allowed(handler) %}
+/**
+{% end %}
+    var show_state_timer;
+    var all_sections = ['attaching', 'detaching', 'detached', 'attached_ok', 'attached_notok'];
+
+    function show_vol_state() {
+        parent.DataVolEBS.volume_status(set_vol_state, error_vol_state);
+    };
+
+    function set_vol_state(vs) {
+        $('#vol_size').html(vs.disk_size);
+        $('#vol_state').show();
+        set_visible_section(vs.state);
+    };
+
+    function set_visible_section(state) {
+        var start_timer = !((state == 0) || (state == 1));
+        var timer_interval = 10000;
+        var show_section = null;
+        if(state == 1) {
+            show_section = 'attached_ok';
+        }
+        else if(state == 0) {
+            show_section = 'detached';
+        }
+        else if(state == 2) {
+            show_section = 'attaching';
+        }
+        else if(state == 3) {
+            show_section = 'detaching';
+        }
+        else if(state == -1) {
+            show_section = 'attached_notok';
+            timer_interval = 60000;
+        }
+
+        for(var idx=0; idx < all_sections.length; idx++) {
+            section = all_sections[idx];
+            if(section == show_section) {
+                $('#vol_' + section).show();
+            }
+            else {
+                $('#vol_' + section).hide();
+            }
+        }
+
+        if(!start_timer && show_state_timer) {
+            clearInterval(show_state_timer);
+            show_state_timer = null;
+        }
+        else if(start_timer && !show_state_timer) {
+            show_state_timer = setInterval(show_vol_state, timer_interval);
+        }
+    };
+
+    function error_vol_state(msg) {
+        $('#vol_state').hide();
+    };
+
+    $(document).ready(function() {
+        $('#btn_vol_attach').click(function(event){
+            event.preventDefault();
+            parent.DataVolEBS.attach(onstrt=function(){
+                set_visible_section(2);
+            });
+        });
+        show_vol_state();
+    });
+{% if not JBoxEBSVolUIModule.is_allowed(handler) %}
+**/
+{% end %}
+</script>
+
+{% if not JBoxEBSVolUIModule.is_allowed(handler) %}
+<span style="display:none">
+{% end %}
+<hr/>
+<h3>Data Volume:</h3>
+    <table class="table">
+	    <tr><td>Size:</td><td><span id='vol_size'>Unknown</span></td></tr>
+        <tr id="vol_state" style="display:none">
+            <td>State:</td>
+            <td>
+                <span id="vol_attaching">Attaching</span>
+                <span id="vol_detaching">Detaching</span>
+                <span id="vol_attached_ok">Attached <small>(/mnt/data)</small></span>
+                <span id="vol_attached_notok">
+                    <small>
+                        Your data volume appears to be in error. <span id="vol_error_state"></span><br/>
+                        Please contact the administrators if it does not recover automatically (may take up to 30 minutes).
+                    </small>
+                </span>
+                <span id="vol_detached">
+                    Detached &nbsp;&nbsp;&nbsp;&nbsp;
+                    <input type="button" value="Attach" id="btn_vol_attach" class="btn btn-primary"/>
+                    <br/>
+                    <small>
+                        Volume will be attached at /mnt/data. It may take up to a minute.<br/>
+                        Logging out will detach the volume and schedule a backup.
+                    </small>
+                </span>
+            </td>
+        </tr>
+</table>
+<br/>
+{% if not JBoxEBSVolUIModule.is_allowed(handler) %}
+</span>
+{% end %}

--- a/engine/src/juliabox/plugins/vol_loopback/loopback.py
+++ b/engine/src/juliabox/plugins/vol_loopback/loopback.py
@@ -65,7 +65,7 @@ class JBoxLoopbackVol(JBoxVol):
                 for disk_id in disk_ids:
                     JBoxLoopbackVol._mark_disk_used(disk_id)
                     nfree -= 1
-            JBoxLoopbackVol.log_info("Disk free: " + str(nfree) + "/" + str(JBoxLoopbackVol.MAX_DISKS))
+            JBoxLoopbackVol.log_info("Loopback Disk free: " + str(nfree) + "/" + str(JBoxLoopbackVol.MAX_DISKS))
         finally:
             JBoxLoopbackVol.LOCK.release()
 

--- a/engine/src/juliabox/vol/volmgr.py
+++ b/engine/src/juliabox/vol/volmgr.py
@@ -139,14 +139,7 @@ class VolMgr(LoggerMixin):
             custom_jimg = '/opt/julia_packages/jimg/stable/sys.ji'
             ipython_profile = 'jboxjulia'
 
-        plugin = None
-        if user.has_resource_profile(JBoxUserV2.RES_PROF_DISK_EBS_1G):
-            plugin = JBoxVol.jbox_get_plugin(JBoxVol.PLUGIN_EBS_USERHOME)
-
-        # if no EBS plugin configured, use the base plugin
-        if plugin is None:
-            plugin = JBoxVol.jbox_get_plugin(JBoxVol.PLUGIN_USERHOME)
-
+        plugin = JBoxVol.jbox_get_plugin(JBoxVol.PLUGIN_USERHOME)
         if plugin is None:
             raise Exception("No plugin found for %s" % (JBoxVol.PLUGIN_USERHOME,))
 

--- a/engine/src/juliabox/vol/volmgr.py
+++ b/engine/src/juliabox/vol/volmgr.py
@@ -71,7 +71,9 @@ class VolMgr(LoggerMixin):
 
     @staticmethod
     def refresh_user_home_image():
-        for plugin in JBoxVol.plugins:
+        for plugin in JBoxVol.jbox_get_plugins(JBoxVol.PLUGIN_USERHOME):
+            plugin.refresh_user_home_image()
+        for plugin in JBoxVol.jbox_get_plugins(JBoxVol.PLUGIN_PKGBUNDLE):
             plugin.refresh_user_home_image()
 
     @staticmethod
@@ -108,11 +110,14 @@ class VolMgr(LoggerMixin):
 
     @staticmethod
     def used_pct():
-        pct = 0.0
+        pct_home = 0.0
         for plugin in JBoxVol.jbox_get_plugins(JBoxVol.PLUGIN_USERHOME):
-            pct += plugin.disk_ids_used_pct()
+            pct_home += plugin.disk_ids_used_pct()
+        pct_data = 0.0
+        for plugin in JBoxVol.jbox_get_plugins(JBoxVol.PLUGIN_DATA):
+            pct_data += plugin.disk_ids_used_pct()
 
-        return min(100, max(0, pct))
+        return min(100, max(pct_data, pct_home))
 
     @staticmethod
     def get_pkg_mount_for_user(email):

--- a/scripts/install/aws/clean_instance.sh
+++ b/scripts/install/aws/clean_instance.sh
@@ -26,3 +26,7 @@ truncate -s 0 .bash_history
 truncate -s 0 /var/awslogs/etc/aws.conf
 
 for id in `docker ps -a | cut -d" " -f1 | grep -v CONTAINER`; do echo $id; docker kill $id; docker rm $id; done
+service docker stop
+cp /jboxengine/data/julia_packages.tar.gz ~/julia_packages.tar.gz
+cp /jboxengine/data/user_home.tar.gz ~/user_home.tar.gz
+umount /jboxengine

--- a/scripts/install/img_create.sh
+++ b/scripts/install/img_create.sh
@@ -20,20 +20,27 @@ function build_web_engines {
         IMGTAG="juliabox/$1"
         DOCKERFILE=${JBOX_DIR}/$2
         DOCKERDIR=$(dirname ${DOCKERFILE})
+        echo ""
+        echo "======================================================"
         echo "Building docker image ${IMGTAG} from ${DOCKERFILE} ..."
+        echo "======================================================"
         sudo docker build -t ${IMGTAG} -f ${DOCKERFILE} ${DOCKERDIR}
         unset IFS
     done
 }
 
 function build_docker_image {
+    echo "======================================================"
     echo "Building docker image ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} ..."
+    echo "======================================================"
     sudo docker build --rm=true -t ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} ${JBOX_DIR}/docker/
     sudo docker tag -f ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} ${DOCKER_IMAGE}:latest
 }
 
 function pull_docker_image {
+    echo "======================================================"
     echo "Pulling docker image ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER} ..."
+    echo "======================================================"
     sudo docker pull tanmaykm/juliabox:${DOCKER_IMAGE_VER}
     sudo docker tag -f tanmaykm/juliabox:${DOCKER_IMAGE_VER} ${DOCKER_IMAGE}:${DOCKER_IMAGE_VER}
     sudo docker tag -f tanmaykm/juliabox:${DOCKER_IMAGE_VER} ${DOCKER_IMAGE}:latest

--- a/scripts/install/unmount_fs.sh
+++ b/scripts/install/unmount_fs.sh
@@ -3,7 +3,7 @@
 
 if [ $# -ne 2 ]
 then
-    echo "Usage: sudo unmount_fs.sh <data_location> [delete fstab entries and files (0/1)]"
+    echo "Usage: sudo unmount_fs.sh <data_location> [delete files (0/1)]"
     exit 1
 fi
 
@@ -17,18 +17,11 @@ DATA_LOC=$1
 FS_DIR=${DATA_LOC}/disks
 LOOP_IMG_DIR=${FS_DIR}/loop/img
 LOOP_MNT_DIR=${FS_DIR}/loop/mnt
-EBS_DIR=${FS_DIR}/ebs
 
 
 function error_exit {
 	echo "$1" 1>&2
 	exit 1
-}
-
-function rm_ebs_fstab_entries {
-    grep -v "$1" /etc/fstab > /tmp/tmpfstab
-    cp /etc/fstab /tmp/fstab.bak
-    cat /tmp/tmpfstab > /etc/fstab
 }
 
 echo "Unmounting..."
@@ -49,6 +42,4 @@ if [ "$2" -eq 1 ]
 then
     echo "Deleting files from ${FS_DIR}..."
     sudo \rm -rf ${FS_DIR}/*
-    echo "Deleting fstab entries..."
-    rm_ebs_fstab_entries ${EBS_DIR}
 fi

--- a/webserver/scripts/router.lua
+++ b/webserver/scripts/router.lua
@@ -207,7 +207,7 @@ function M.jbox_route()
         M.set_forward_addr(8888, "http", 8888)
         if (uri == "/") or ngx.re.match(uri, "/jboxauth/.+") then
             ngx.var.jbox_forward_addr = M.check_forward_addr(ngx.var.jbox_forward_addr, "http://127.0.0.1:8888")
-        else
+        elseif not ngx.re.match(uri, "/jboxcors/.*") then
             M.forbid_invalid_session()
         end
         ngx.log(ngx.DEBUG, "final forward_addr: " .. ngx.var.jbox_forward_addr)

--- a/webserver/www/assets/plugins/vol_ebs/vol_ebs.js
+++ b/webserver/www/assets/plugins/vol_ebs/vol_ebs.js
@@ -1,0 +1,86 @@
+var DataVolEBS = (function($, _, undefined){
+	var _inop = false;
+
+	var self = {
+        attach: function (onstrt) {
+            s = function(res) {
+            	if (res.code == 0) {
+            	    resp = res.data
+            		JuliaBox.popup_alert("Attaching data volume.");
+            		if(onstrt){
+            			onstrt();
+            		}
+            	}
+            	else {
+					if (res.data) {
+						JuliaBox.popup_alert("Error attaching data volume. " + res.data);
+					}
+					else {
+						JuliaBox.popup_alert("Unknown error attaching data volume.");
+					}
+            	}
+            };
+            f = function() {
+				JuliaBox.popup_alert("Communication error while attaching data volume.");
+            };
+            self._inop = true;
+            var msg = 'Attach your data disk?';
+    		JuliaBox.popup_confirm(msg, function(res) {
+            	self._inop = false;
+    			if(res) {
+					JuliaBox.comm('/jboxplugin/ebsdatavol/', 'GET', { 'action': 'attach' }, s, f);
+				}
+			});
+        },
+
+        detach: function (onstrt) {
+            s = function(res) {
+            	if (res.code == 0) {
+            	    resp = res.data
+            		JuliaBox.popup_alert("Detaching data volume.");
+            		if(onstrt){
+            			onstrt();
+            		}
+            	}
+            	else {
+					if (res.data) {
+						JuliaBox.popup_alert("Error detaching data volume. " + res.data);
+					}
+					else {
+						JuliaBox.popup_alert("Unknown error detaching data volume.");
+					}
+            	}
+            };
+            f = function() {
+				JuliaBox.popup_alert("Communication error while detaching data volume.");
+            };
+            self._inop = true;
+            var msg = 'Detach your data disk?';
+    		JuliaBox.popup_confirm(msg, function(res) {
+            	self._inop = false;
+    			if(res) {
+					JuliaBox.comm('/jboxplugin/ebsdatavol/', 'GET', { 'action': 'detach' }, s, f);
+				}
+			});
+        },
+
+        volume_status: function (cb_success, cb_failure) {
+        	if(self._inop) {
+        		return;
+        	}
+            s = function(res) {
+            	if (res.code == 0) {
+            	    cb_success(res.data)
+            	}
+            	else {
+            	    cb_failure(res.data)
+            	}
+            };
+            f = function() {
+                cb_failure(null)
+            };
+            JuliaBox.comm('/jboxplugin/ebsdatavol/', 'GET', { 'action': 'status' }, s, f, dolock=false);
+        }
+	};
+	return self;
+})(jQuery, _);


### PR DESCRIPTION
EBS volumes often take a long time to mount. There are also multiple steps involved in attaching and mounting it on to a container and a failure in any step makes it difficult to recover cleanly.

This PR changes EBS volumes to be mounted as data volumes only.
- Volumes can be mounted from the JuliaBox configuration tab
- Periodic cleanup tasks monitor aborted/failure situations (often a timeout/user abandoning the session) and can recover from most

Sessions now always get redirected to instances that have a previous container for the same user. This previously relied on cookies and AWS load balancer, and broke unless the user used the same browser the second time. Now re-loading a session with a mounted data volume retains its state.