### PR TITLE
replaceable database backend

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 # Docker file for JuliaBox
-# Version:33
+# Version:34
 
-FROM julialang/juliaboxpkgdist:v0.3.10
+#FROM julialang/juliaboxpkgdist:v0.3.11
 # Switching the base to the bare julia image helps during JuliaBox development by reducing image size
-#FROM julialang/julia:v0.3.10
+FROM julialang/julia:v0.3.11
 
 MAINTAINER Tanmay Mohapatra
 
@@ -25,7 +25,7 @@ RUN ln -fs /opt/julia_0.4.0 /opt/julia_nightly
 # They are added to LOAD_PATH through respective juliarc.jl scripts.
 RUN mkdir /opt/julia_packages
 RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.4/")' >> /opt/julia_0.4.0/etc/julia/juliarc.jl
-RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/")' >> /opt/julia_0.3.10/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/")' >> /opt/julia_0.3.11/etc/julia/juliarc.jl
 
 # Data volumes shall be mounted at /mnt/data
 RUN mkdir /mnt/data

--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -110,6 +110,7 @@ Welcome to JuliaBox. We hope you will like it and also share with your friends.
         "juliabox.plugins.course_homework",
         "juliabox.plugins.parallel",
         "juliabox.plugins.auth_google",
+        "juliabox.plugins.usage_accounting",
         ""
     ],
 

--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -52,7 +52,6 @@
 
     	# Enable/disable features
     	"s3": True,
-    	"dynamodb": True,
     	"cloudwatch": True,
     	"autoscale": True,
     	"route53": True,
@@ -103,6 +102,14 @@ Welcome to JuliaBox. We hope you will like it and also share with your friends.
     "user_home_image" : "/jboxengine/data/user_home.tar.gz",
     "pkg_image": "/jboxengine/data/julia_packages.tar.gz",
 
+    "db": {
+        # default connect string for sqlite database
+        "connect_str": "/jboxengine/data/db/juliabox.db",
+        # table name mappings
+        # "tables" : {
+        # }
+    },
+
     "plugins": [
         "juliabox.plugins.vol_loopback",
         "juliabox.plugins.vol_ebs",
@@ -111,6 +118,7 @@ Welcome to JuliaBox. We hope you will like it and also share with your friends.
         "juliabox.plugins.parallel",
         "juliabox.plugins.auth_google",
         "juliabox.plugins.usage_accounting",
+        "juliabox.plugins.db_dynamodb",
         ""
     ],
 

--- a/engine/src/juliabox/cloud/aws.py
+++ b/engine/src/juliabox/cloud/aws.py
@@ -171,11 +171,9 @@ class CloudHost(LoggerMixin):
     @staticmethod
     def configure():
         CloudHost.ENABLED['s3'] = JBoxCfg.get('cloud_host.s3', True)
-        CloudHost.ENABLED['dynamodb'] = JBoxCfg.get('cloud_host.dynamodb', True)
         CloudHost.ENABLED['cloudwatch'] = JBoxCfg.get('cloud_host.cloudwatch', True)
         CloudHost.ENABLED['autoscale'] = JBoxCfg.get('cloud_host.autoscale', True)
         CloudHost.ENABLED['route53'] = JBoxCfg.get('cloud_host.route53', True)
-        CloudHost.ENABLED['ebs'] = JBoxCfg.get('cloud_host.ebs', True)
         CloudHost.ENABLED['ses'] = JBoxCfg.get('cloud_host.ses', True)
 
         CloudHost.SCALE_UP_AT_LOAD = JBoxCfg.get('cloud_host.scale_up_at_load', 80)

--- a/engine/src/juliabox/db/__init__.py
+++ b/engine/src/juliabox/db/__init__.py
@@ -1,7 +1,6 @@
 __author__ = 'tan'
 from db_base import JBoxDB, JBoxDBPlugin
 from user_v2 import JBoxUserV2
-from accounting_v2 import JBoxAccountingV2
 from container import JBoxSessionProps
 from dynconfig import JBoxDynConfig
 from juliabox.cloud.aws import CloudHost
@@ -10,7 +9,6 @@ from juliabox.jbox_util import JBoxCfg
 
 def configure():
     JBoxUserV2.NAME = JBoxCfg.get('cloud_host.cloud_cfg', JBoxUserV2.NAME)
-    JBoxAccountingV2.NAME = JBoxCfg.get('cloud_host.jbox_accounting_v2', JBoxAccountingV2.NAME)
     JBoxSessionProps.NAME = JBoxCfg.get('cloud_host.jbox_session', JBoxSessionProps.NAME)
     JBoxDynConfig.NAME = JBoxCfg.get('cloud_host.jbox_dynconfig', JBoxDynConfig.NAME)
 

--- a/engine/src/juliabox/db/__init__.py
+++ b/engine/src/juliabox/db/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'tan'
-from db_base import JBoxDB, JBoxDBPlugin
+from db_base import JBoxDB, JBoxDBPlugin, JBoxDBItemNotFound
 from user_v2 import JBoxUserV2
 from container import JBoxSessionProps
 from dynconfig import JBoxDynConfig
@@ -8,13 +8,17 @@ from juliabox.jbox_util import JBoxCfg
 
 
 def configure():
-    JBoxUserV2.NAME = JBoxCfg.get('cloud_host.cloud_cfg', JBoxUserV2.NAME)
-    JBoxSessionProps.NAME = JBoxCfg.get('cloud_host.jbox_session', JBoxSessionProps.NAME)
-    JBoxDynConfig.NAME = JBoxCfg.get('cloud_host.jbox_dynconfig', JBoxDynConfig.NAME)
+    JBoxDB.configure()
+    tablenames = JBoxCfg.get('db.tables', dict())
 
-    for plugin in JBoxDBPlugin.plugins:
+    for cls in (JBoxUserV2, JBoxSessionProps, JBoxDynConfig):
+        cls.NAME = tablenames.get(cls.NAME, cls.NAME)
+        JBoxDB.log_info("%s provided by table %s", cls.__name__, cls.NAME)
+
+    for plugin in JBoxDBPlugin.jbox_get_plugins(JBoxDBPlugin.PLUGIN_TABLE):
         JBoxDB.log_info("Found plugin %r provides %r", plugin, plugin.provides)
-        plugin.NAME = JBoxCfg.get('cloud_host.' + plugin.NAME, plugin.NAME)
+        plugin.NAME = tablenames.get(plugin.NAME, plugin.NAME)
+        JBoxDB.log_info("%s provided by table %s", plugin.__name__, plugin.NAME)
 
 
 def is_proposed_cluster_leader():

--- a/engine/src/juliabox/db/db_base.py
+++ b/engine/src/juliabox/db/db_base.py
@@ -77,16 +77,22 @@ class JBoxDBPlugin(JBoxDB):
     DynamoDB is the only type of database supported as of now.
 
     It is a plugin mount point, looking for features:
-    - dynamodb.table (tables hosted on dynamodb)
+    - db.table.dynamodb (tables hosted on dynamodb)
+    - db.usage.accounting (table that records usage accounting)
 
-    Plugins are expected to have:
+    DynamoDB table providers are expected to have:
     - NAME: attribute holding table name
     - SCHEMA and INDEXES: attributes holding table structure
     - TABLE: attribute to hold the table reference
+
+    Usage accounting providers (may be moved later to a separate plugin) are expected to have:
+    - record_session_time method:record start and end times of a session
+    - get_stats method: provide usage statistics for a given range of dates
 
     Plugins can take help of base methods provided in JBoxDB.
     """
 
     PLUGIN_DYNAMODB_TABLE = "db.table.dynamodb"
+    PLUGIN_USAGE_ACCOUNTING = "db.usage.accounting"
 
     __metaclass__ = JBoxPluginType

--- a/engine/src/juliabox/db/dynconfig.py
+++ b/engine/src/juliabox/db/dynconfig.py
@@ -141,7 +141,8 @@ class JBoxDynConfig(JBoxDB):
             return msg['msg']
 
         if del_expired:
-            JBoxDynConfig.table().delete_item(name='.'.join([cluster, 'message']))
+            record.delete()
+            # JBoxDynConfig.table().delete_item(name='.'.join([cluster, 'message']))
 
         return None
 

--- a/engine/src/juliabox/handlers/admin.py
+++ b/engine/src/juliabox/handlers/admin.py
@@ -3,11 +3,11 @@ from datetime import datetime, timedelta
 import isodate
 
 from juliabox.cloud.aws import CloudHost
-from juliabox.jbox_util import unquote, JBoxCfg
+from juliabox.jbox_util import JBoxCfg
 from handler_base import JBoxHandler
 from juliabox.jbox_container import JBoxContainer
 from juliabox.jbox_tasks import JBoxAsyncJob
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxAccountingV2
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxDBPlugin
 
 
 class AdminHandler(JBoxHandler):
@@ -145,12 +145,16 @@ class AdminHandler(JBoxHandler):
 
     @staticmethod
     def get_session_stats():
+        plugin = JBoxDBPlugin.jbox_get_plugin(JBoxDBPlugin.PLUGIN_USAGE_ACCOUNTING)
+        if plugin is None:
+            return None
+
         today = datetime.now()
         week_dates = [today - timedelta(days=i) for i in range(6, -1, -1)]
         today_dates = [today]
         stats = {
-            'day': JBoxAccountingV2.get_stats(today_dates),
-            'week': JBoxAccountingV2.get_stats(week_dates)
+            'day': plugin.get_stats(today_dates),
+            'week': plugin.get_stats(week_dates)
         }
         return stats
 

--- a/engine/src/juliabox/plugins/db_dynamodb/__init__.py
+++ b/engine/src/juliabox/plugins/db_dynamodb/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'tan'
+from impl_dynamodb import JBoxDynamoDB

--- a/engine/src/juliabox/plugins/db_dynamodb/impl_dynamodb.py
+++ b/engine/src/juliabox/plugins/db_dynamodb/impl_dynamodb.py
@@ -1,0 +1,52 @@
+__author__ = 'tan'
+
+from boto.dynamodb2.exceptions import ItemNotFound
+from boto.dynamodb2.table import Table
+
+from juliabox.db import JBoxDBPlugin, JBoxDBItemNotFound
+
+
+class JBoxDynamoDB(JBoxDBPlugin):
+    provides = [JBoxDBPlugin.PLUGIN_DB, JBoxDBPlugin.PLUGIN_DB_DYNAMODB]
+
+    @staticmethod
+    def configure():
+        pass
+
+    @staticmethod
+    def table_open(tablename):
+        return Table(tablename)
+
+    @staticmethod
+    def record_create(table, data):
+        if not table.put_item(data=data):
+            raise Exception("Error creating record")
+
+    @staticmethod
+    def record_fetch(table, **kwargs):
+        try:
+            return table.get_item(**kwargs)
+        except ItemNotFound:
+            raise JBoxDBItemNotFound()
+
+    @staticmethod
+    def record_scan(table, **kwargs):
+        return table.scan(**kwargs)
+
+    @staticmethod
+    def record_query(table, **kwargs):
+        return table.query_2(**kwargs)
+
+    @staticmethod
+    def record_count(table, **kwargs):
+        return table.query_count(**kwargs)
+
+    @staticmethod
+    def record_save(table, record):
+        if table is not None:
+            record.save()
+
+    @staticmethod
+    def record_delete(table, record):
+        if table is not None:
+            record.delete()

--- a/engine/src/juliabox/plugins/db_sqlite3/__init__.py
+++ b/engine/src/juliabox/plugins/db_sqlite3/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'tan'
+from impl_sqlite3 import JBoxSQLite3

--- a/engine/src/juliabox/plugins/db_sqlite3/impl_sqlite3.py
+++ b/engine/src/juliabox/plugins/db_sqlite3/impl_sqlite3.py
@@ -1,0 +1,216 @@
+__author__ = 'tan'
+
+import threading
+import sqlite3
+
+from juliabox.db import JBoxDBPlugin, JBoxDBItemNotFound
+from juliabox.jbox_util import JBoxCfg, LoggerMixin
+
+
+class JBoxSQLiteTable(LoggerMixin):
+    OP = {
+        'eq': (' = ?', lambda x: x),
+        'ne': (' != ?', lambda x: x),
+        'le': (' <= ?', lambda x: x),
+        'lt': (' < ?', lambda x: x),
+        'ge': (' >= ?', lambda x: x),
+        'gt': (' > ?', lambda x: x),
+        'beginswith': (' like ?', lambda x: x + '%'),
+        'between': (' between ? and ?', lambda x: x)
+    }
+
+    def __init__(self, table_name):
+        self.name = table_name
+        c = JBoxSQLite3.conn().cursor()
+        pragma_sql = 'pragma table_info("%s")' % (table_name,)
+        c.execute(pragma_sql)
+        rows = c.fetchall()
+        pragma_cols = [spec[0] for spec in c.description]
+
+        columns = []
+        pk = []
+        for row in rows:
+            rowdict = dict(zip(pragma_cols, row))
+            colname = rowdict['name']
+            columns.append(colname)
+            if rowdict['pk'] == 1:
+                pk.append(colname)
+        c.close()
+        self.columns = columns
+        self.pk = pk
+        self.insert_statement = "insert into " + table_name + \
+                                " (" + ", ".join(self.columns) + ")" + \
+                                " values (" + ", ".join(['?'] * len(self.columns)) + ")"
+
+    def insert(self, record):
+        values = []
+        for colname in self.columns:
+            values.append(record[colname] if colname in record else None)
+        c = JBoxSQLite3.conn().cursor()
+        c.execute(self.insert_statement, tuple(values))
+        c.close()
+        self.commit()
+
+    @staticmethod
+    def _op(name, opstr, value, names, values):
+        namestr, valsf = JBoxSQLiteTable.OP[opstr]
+        vals = valsf(value)
+        names.append(name + namestr)
+        if isinstance(vals, (list, tuple)):
+            values.extend(vals)
+        else:
+            values.append(vals)
+
+    def _select(self, count, **kwargs):
+        names = []
+        values = []
+        for (n, v) in kwargs.iteritems():
+            ncomps = n.split('__')
+            colname = ncomps[0]
+            if colname not in self.columns:
+                continue
+            op = ncomps[1] if len(ncomps) > 1 else "eq"
+            JBoxSQLiteTable._op(colname, op, v, names, values)
+
+        selattribs = 'count(*)' if count else '*'
+        if len(names) > 0:
+            criteria = ' where ' + ' and '.join(names)
+        else:
+            criteria = ''
+        stmt = 'select %s from %s%s' % (selattribs, self.name, criteria)
+
+        c = JBoxSQLite3.conn().cursor()
+        c.execute(stmt, tuple(values))
+        return c
+
+    def select(self, **kwargs):
+        c = self._select(False, **kwargs)
+        row = c.fetchone()
+        if row is None:
+            raise JBoxDBItemNotFound()
+
+        item = dict(zip(self.columns, row))
+        c.close()
+        return item
+
+    def scan(self, **kwargs):
+        c = self._select(False, **kwargs)
+        return (dict(zip(self.columns, row)) for row in c)
+
+    def count(self, **kwargs):
+        c = self._select(True, **kwargs)
+        row = c.fetchone()
+        if row is None:
+            return 0
+        return row[0]
+
+    def delete(self, record):
+        names = []
+        values = []
+        for keyname in self.pk:
+            keyval = record.get(keyname, None)
+            if keyval is None:
+                continue
+            names.append("%s = ?" % (keyname,))
+            values.append(keyval)
+
+        if len(names) != len(self.pk):
+            raise JBoxDBItemNotFound()
+        criteria = ' where ' + ' and '.join(names)
+        stmt = "delete from %s%s" % (self.name, criteria)
+
+        c = JBoxSQLite3.conn().cursor()
+        # self.log_debug("SQL: %s", stmt)
+        c.execute(stmt, tuple(values))
+        c.close()
+        self.commit()
+
+    def update(self, record):
+        keynames = []
+        updates = []
+        values = []
+
+        for keyname in self.columns:
+            if keyname in self.pk:
+                continue
+            keyval = record.get(keyname, None)
+            updates.append("%s = ?" % (keyname,))
+            values.append(keyval)
+        updatecols = ', '.join(updates)
+
+        for keyname in self.pk:
+            keyval = record.get(keyname, None)
+            if keyval is None:
+                continue
+            keynames.append("%s = ?" % (keyname,))
+            values.append(keyval)
+
+        if len(keynames) != len(self.pk):
+            raise JBoxDBItemNotFound()
+        criteria = ' where ' + ' and '.join(keynames)
+
+        stmt = "update %s set %s%s" % (self.name, updatecols, criteria)
+
+        c = JBoxSQLite3.conn().cursor()
+        # self.log_debug("SQL: %s", stmt)
+        c.execute(stmt, tuple(values))
+        c.close()
+        self.commit()
+
+    @staticmethod
+    def commit():
+        JBoxSQLite3.conn().commit()
+
+
+class JBoxSQLite3(JBoxDBPlugin):
+    provides = [JBoxDBPlugin.PLUGIN_DB, JBoxDBPlugin.PLUGIN_DB_RDBMS]
+
+    threadlocal = threading.local()
+    CONNECT_STR = ":memory:" # default to an in-memory database
+
+    @staticmethod
+    def configure():
+        dbconf = JBoxCfg.get("db")
+        JBoxSQLite3.log_debug("db_conf: %r", dbconf)
+        if dbconf is not None and 'connect_str' in dbconf:
+            JBoxSQLite3.CONNECT_STR = dbconf['connect_str']
+
+    @staticmethod
+    def conn():
+        c = getattr(JBoxSQLite3.threadlocal, 'sqlite_conn', None)
+        if c is None:
+            JBoxSQLite3.log_debug("connecting with %s", JBoxSQLite3.CONNECT_STR)
+            JBoxSQLite3.threadlocal.sqlite_conn = c = sqlite3.connect(JBoxSQLite3.CONNECT_STR)
+        return c
+
+    @staticmethod
+    def table_open(tablename):
+        return JBoxSQLiteTable(tablename)
+
+    @staticmethod
+    def record_create(table, data):
+        table.insert(data)
+
+    @staticmethod
+    def record_fetch(table, **kwargs):
+        return table.select(**kwargs)
+
+    @staticmethod
+    def record_scan(table, **kwargs):
+        return table.scan(**kwargs)
+
+    @staticmethod
+    def record_query(table, **kwargs):
+        return table.scan(**kwargs)
+
+    @staticmethod
+    def record_count(table, **kwargs):
+        return table.count(**kwargs)
+
+    @staticmethod
+    def record_save(table, record):
+        table.update(record)
+
+    @staticmethod
+    def record_delete(table, record):
+        table.delete(record)

--- a/engine/src/juliabox/plugins/usage_accounting/__init__.py
+++ b/engine/src/juliabox/plugins/usage_accounting/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'tan'
+from usage_accounting_tbl import JBoxAccountingV2

--- a/engine/src/juliabox/plugins/usage_accounting/usage_accounting_tbl.py
+++ b/engine/src/juliabox/plugins/usage_accounting/usage_accounting_tbl.py
@@ -34,9 +34,6 @@ class JBoxAccountingV2(JBoxDBPlugin):
     _stats_cache = {}
 
     def __init__(self, container_id, image_id, start_time, stop_time=None):
-        if None == self.table():
-            return
-
         if None == stop_time:
             stop_datetime = datetime.datetime.now(pytz.utc)
         else:
@@ -53,15 +50,12 @@ class JBoxAccountingV2(JBoxDBPlugin):
             'start_date': JBoxAccountingV2.datetime_to_yyyymmdd(start_time)
         }
         self.create(data)
-        self.item = self.table().get_item(stop_date=stop_date, stop_time=stop_time)
+        self.item = self.fetch(stop_date=stop_date, stop_time=stop_time)
         self.is_new = True
 
     @staticmethod
     def _query_stats_date(date):
         # TODO: caching items is not a good idea. Should cache computed data instead.
-        if None == JBoxAccountingV2.table():
-            return []
-
         today = datetime.datetime.now()
         date_day = JBoxAccountingV2.datetime_to_yyyymmdd(date)
         today_day = JBoxAccountingV2.datetime_to_yyyymmdd(today)
@@ -70,7 +64,7 @@ class JBoxAccountingV2(JBoxDBPlugin):
         if date_day in JBoxAccountingV2._stats_cache:
             return JBoxAccountingV2._stats_cache[date_day]
 
-        res = JBoxAccountingV2.table().query_2(stop_date__eq=date_day, stop_time__gte=0)
+        res = JBoxAccountingV2.query(stop_date__eq=date_day, stop_time__gte=0)
 
         items = []
         for item in res:

--- a/scripts/install/create_tables_dynamodb.py
+++ b/scripts/install/create_tables_dynamodb.py
@@ -2,11 +2,12 @@
 
 from boto.dynamodb2.table import Table
 
-from juliabox.db import JBoxUserV2, JBoxAccountingV2, JBoxDynConfig, \
-    JBoxSessionProps, JBoxDBPlugin
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxDBPlugin
 
 # import any plugins that contribute tables
 import juliabox.plugins.course_homework
+import juliabox.plugins.usage_accounting
+import juliabox.plugins.vol_ebs
 
 
 def table_exists(name):
@@ -17,7 +18,7 @@ def table_exists(name):
     except:
         return False
 
-tables = [JBoxUserV2, JBoxAccountingV2, JBoxDynConfig, JBoxSessionProps]
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps]
 for plugin in JBoxDBPlugin.plugins:
     tables.append(plugin)
 

--- a/scripts/install/create_tables_dynamodb.py
+++ b/scripts/install/create_tables_dynamodb.py
@@ -19,7 +19,7 @@ def table_exists(name):
         return False
 
 tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps]
-for plugin in JBoxDBPlugin.plugins:
+for plugin in JBoxDBPlugin.jbox_get_plugins(JBoxDBPlugin.PLUGIN_DYNAMODB_TABLE):
     tables.append(plugin)
 
 for cls in tables:

--- a/scripts/install/create_tables_sqlite.py
+++ b/scripts/install/create_tables_sqlite.py
@@ -1,0 +1,44 @@
+#! /usr/bin/env python
+
+import sys
+import sqlite3
+
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxDBPlugin
+
+# import any plugins that contribute tables
+import juliabox.plugins.course_homework
+
+
+def table_exists(table_name):
+    try:
+        c.execute("select * from %s where 1=0" % (table_name,))
+        c.fetchall()
+        return c.description is not None
+    except:
+        return False
+
+
+def table_create(table_name, columns, keys=None):
+    allcolumns = columns if keys is None else keys + columns
+    sql = 'create table %s (%s' % (table_name, ', '.join(allcolumns))
+    if keys is not None:
+        sql += (', primary key (%s)' % (', '.join(keys),))
+    sql += ')'
+    c.execute(sql)
+    conn.commit()
+
+print("connecting to %s" % (sys.argv[1],))
+conn = sqlite3.connect(sys.argv[1])
+c = conn.cursor()
+
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps]
+for plugin in JBoxDBPlugin.jbox_get_plugins(JBoxDBPlugin.PLUGIN_RDBMS_TABLE):
+    tables.append(plugin)
+
+for cls in tables:
+    print("Creating %s..." % (cls.NAME,))
+    if table_exists(cls.NAME):
+        print("\texists already!")
+    else:
+        table_create(cls.NAME, cls.ATTRIBUTES, cls.KEYS)
+        print("\tcreated.")

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -2,7 +2,7 @@ import datetime
 
 import docker
 
-from db import JBoxDynConfig, JBoxAccountingV2, JBoxSessionProps, JBoxUserV2
+from db import JBoxDynConfig, JBoxSessionProps, JBoxUserV2
 from jbox_util import read_config, LoggerMixin, unique_sessname
 from juliabox import db
 from juliabox.cloud.aws import CloudHost
@@ -37,12 +37,6 @@ TESTCLSTR = 'testcluster'
 class TestDBTables(LoggerMixin):
     @staticmethod
     def test():
-        yday = datetime.datetime.now() - datetime.timedelta(hours=24)
-        stats = JBoxAccountingV2.get_stats(dates=(yday,))
-        TestDBTables.log_debug("stats for yesterday: %s", repr(stats))
-        stats = JBoxAccountingV2.get_stats()
-        TestDBTables.log_debug("stats for today: %s", repr(stats))
-
         sprops = JBoxSessionProps(unique_sessname('tanmaykm@gmail.com'))
         TestDBTables.log_debug("JBoxSessionProps. user_id: %s, snapshot_id: %s, message: %s",
                                sprops.get_user_id(),

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -17,7 +17,6 @@ LoggerMixin.DEFAULT_LEVEL = cfg['jbox_log_level']
 db.configure_db(cfg)
 
 CloudHost.configure(has_s3=cloud_cfg['s3'],
-                    has_dynamodb=cloud_cfg['dynamodb'],
                     has_cloudwatch=cloud_cfg['cloudwatch'],
                     has_autoscale=cloud_cfg['autoscale'],
                     has_route53=cloud_cfg['route53'],


### PR DESCRIPTION
Database backend is now pluggable and can be replaced with a different implementation that must provide a few simple CRUD methods. Tables are mostly designed as key-value stores with no requirement of transactions/foreign keys, and are easy to adapt to different backends.

Included are implementations for:
- dynamodb: for deployments on AWS
- sqlite: for local/development setups

Also includes a minor update of Julia to 0.3.11.