### PR TITLE
volume plugin: shared host machine folder for user home

### DIFF
--- a/docs/INSTALL.MD
+++ b/docs/INSTALL.MD
@@ -24,7 +24,7 @@ Installing JuliaBox on a single machine consists of five principal steps, the sp
 
 	The `jbox_configure.sh` script is executed to configure the JuliaBox installation secret (used as part of encryption key for signing and encrypting session data), and to move the server configuration templates to the work directories (from where they will be mounted by the Docker containers).
 	
-	The `mount_fs.sh` script is executed to configure user home directories. The location, size and number of directories is specified to the script which:
+	On multiuser installations, if it is required to impose limits on available disk space, the `mount_fs.sh` script is executed to configure user home directories. The location, size and number of directories is specified to the script which:
 	
 	- makes subdirectories to store disk images and form mount points,
 	- creates and formats blank disk images in each subdirectory,
@@ -87,7 +87,7 @@ The following procedure will configure a system without authentication, designed
     	- Modify `JuliaBox/scripts/install/sys_install.sh` and set `DOCKER_FS` to `AUFS` instead of `DEVICEMAPPER`. This will avoid certain unnecessary configurations required only in certain production environments.
     	- Run `JuliaBox/scripts/install/sys_install.sh`.
 	- Create work folders:
-		- Execute `sudo mkdir -p /jboxengine/conf /jboxengine/data /jboxengine/data/db`.
+		- Execute `sudo mkdir -p /jboxengine/conf /jboxengine/data/db /jboxengine/data/disks/host`.
 		- Take ownership `sudo chown -R $USER: /jboxengine`.
 
 
@@ -100,9 +100,11 @@ The following procedure will configure a system without authentication, designed
     	"interactive": {
         	"numlocalmax": 2
         },
+        "mnt_location" : "/jboxengine/data/disks/host",
+        "backup_location" : None,
         "plugins": [
             "juliabox.plugins.compute_singlenode",
-            "juliabox.plugins.vol_loopback",
+            "juliabox.plugins.vol_hostdisk",
             "juliabox.plugins.vol_defpkg",
             "juliabox.plugins.auth_zero",
             "juliabox.plugins.db_sqlite3"
@@ -111,8 +113,6 @@ The following procedure will configure a system without authentication, designed
     </pre>
     - Generate JuliaBox configuration files:
 		- Run `JuliaBox/scripts/install/jbox_configure.sh`.
-	- Create disk images, loopback devices, and mount:
-		- Run `sudo JuliaBox/scripts/install/mount_fs.sh /jboxengine/data 3 500 ${USER}` 
 
 3. *JuliaBox* Docker image creation.
 	
@@ -142,7 +142,6 @@ The following procedure will configure a system without authentication, designed
 6. Launch JuliaBox:
     - To start: `JuliaBox/scripts/run/start.sh`
     - To stop: `JuliaBox/scripts/run/stop.sh`
-    - If starting JuliaBox after a system reboot, re-mount the loopback devices by running `mount_fs.sh` as specified in the configuration step above.
 
 ### Multi-user with Google OAuth authentication
 
@@ -182,7 +181,7 @@ The following procedure will configure a system without authentication, designed
 		- Run `JuliaBox/scripts/install/jbox_configure.sh`.
 	- Create disk images, loopback devices, and mount:
 		- Run `sudo JuliaBox/scripts/install/mount_fs.sh /jboxengine/data 30 500 ${USER}`
-
+    - If starting JuliaBox after a system reboot, re-mount the loopback devices by running `mount_fs.sh` as specified in the configuration step above.
 
 ## AWS Cluster Setup
 

--- a/engine/src/juliabox/plugins/vol_hostdisk/__init__.py
+++ b/engine/src/juliabox/plugins/vol_hostdisk/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'tan'
+from hostdisk import JBoxHostDiskVol

--- a/engine/src/juliabox/plugins/vol_hostdisk/hostdisk.py
+++ b/engine/src/juliabox/plugins/vol_hostdisk/hostdisk.py
@@ -1,0 +1,109 @@
+import os
+import psutil
+
+from juliabox.jbox_util import ensure_delete, JBoxCfg, unique_sessname
+from juliabox.vol import JBoxVol
+
+
+class JBoxHostDiskVol(JBoxVol):
+    provides = [JBoxVol.JBP_USERHOME, JBoxVol.JBP_USERHOME_LOCAL]
+
+    FS_LOC = None
+
+    @staticmethod
+    def configure():
+        JBoxHostDiskVol.FS_LOC = os.path.expanduser(JBoxCfg.get('mnt_location'))
+        JBoxHostDiskVol.refresh_disk_use_status()
+
+    @classmethod
+    def get_disk_allocated_size(cls):
+        try:
+            return psutil.disk_usage(JBoxHostDiskVol.FS_LOC).total
+        except:
+            return 0
+
+    @staticmethod
+    def _get_disk_ids_used(cid):
+        used = []
+        try:
+            props = JBoxHostDiskVol.dckr().inspect_container(cid)
+            vols = props['Volumes']
+            for _cpath, hpath in vols.iteritems():
+                if hpath.startswith(JBoxHostDiskVol.FS_LOC):
+                    used.append(hpath.split('/')[-1])
+        except:
+            JBoxHostDiskVol.log_exception("error finding disk ids used in " + cid)
+            return []
+        return used
+
+    @staticmethod
+    def refresh_disk_use_status(container_id_list=None):
+        pass
+
+    @staticmethod
+    def disk_ids_used_pct():
+        try:
+            return psutil.disk_usage(JBoxHostDiskVol.FS_LOC).percent
+        except:
+            return 0
+
+    @staticmethod
+    def get_disk_for_user(user_email):
+        JBoxHostDiskVol.log_debug("creating host disk for %s", user_email)
+
+        disk_id = unique_sessname(user_email)
+        disk_path = os.path.join(JBoxHostDiskVol.FS_LOC, disk_id)
+        if not os.path.exists(disk_path):
+            os.mkdir(disk_path)
+        hostvol = JBoxHostDiskVol(disk_path, user_email=user_email)
+        hostvol.refresh_disk(mark_refreshed=False)
+
+        if JBoxVol.BACKUP_LOC is not None:
+            JBoxHostDiskVol.log_debug("restoring data for %s", user_email)
+            hostvol.restore()
+
+        return hostvol
+
+    @staticmethod
+    def is_mount_path(fs_path):
+        return fs_path.startswith(JBoxHostDiskVol.FS_LOC)
+
+    @staticmethod
+    def get_disk_from_container(cid):
+        disk_ids_used = JBoxHostDiskVol._get_disk_ids_used(cid)
+        if len(disk_ids_used) == 0:
+            return None
+
+        disk_id_used = disk_ids_used[0]
+        disk_path = os.path.join(JBoxHostDiskVol.FS_LOC, disk_id_used)
+        container_name = JBoxVol.get_cname(cid)
+        sessname = container_name[1:]
+        return JBoxHostDiskVol(disk_path, sessname=sessname)
+
+    @staticmethod
+    def refresh_user_home_image():
+        pass
+
+    def _backup(self, clear_volume=True):
+        if JBoxVol.BACKUP_LOC is not None:
+            super(JBoxHostDiskVol, self)._backup(clear_volume=clear_volume)
+
+    def refresh_disk(self, mark_refreshed=True):
+        if JBoxVol.BACKUP_LOC is None:
+            self.log_debug("restoring common data on disk at %s", self.disk_path)
+            self.restore_user_home(False)
+        else:
+            self.log_debug("blanking out disk at %s", self.disk_path)
+            ensure_delete(self.disk_path)
+            self.log_debug("restoring common data on disk at %s", self.disk_path)
+            self.restore_user_home(True)
+
+        self.setup_instance_config()
+        if mark_refreshed:
+            self.mark_refreshed()
+        self.log_debug("refreshed disk at %s", self.disk_path)
+
+    def release(self, backup=False):
+        if backup:
+            self._backup()
+        self.refresh_disk()

--- a/engine/src/juliabox/plugins/vol_loopback/loopback.py
+++ b/engine/src/juliabox/plugins/vol_loopback/loopback.py
@@ -12,9 +12,7 @@ class JBoxLoopbackVol(JBoxVol):
 
     FS_LOC = None
     DISK_LIMIT = None
-    MAX_CONTAINERS = 0
     MAX_DISKS = 0
-    VALID_CONTAINERS = {}
     DISK_USE_STATUS = {}
     DISK_RESERVE_TIME = {}
     LOCK = None

--- a/engine/src/juliabox/vol/jbox_volume.py
+++ b/engine/src/juliabox/vol/jbox_volume.py
@@ -110,14 +110,16 @@ class JBoxVol(LoggerMixin):
     # this is template method
     @staticmethod
     def configure():
-        backup_location = os.path.expanduser(JBoxCfg.get('backup_location'))
-        make_sure_path_exists(backup_location)
+        backup_location = JBoxCfg.get('backup_location')
+        if backup_location is not None:
+            backup_location = os.path.expanduser(backup_location)
+            make_sure_path_exists(backup_location)
+            JBoxVol.BACKUP_LOC = backup_location
 
         JBoxVol.DCKR = JBoxCfg.dckr
         JBoxVol.NOTEBOOK_WEBSOCK_PROTO = JBoxCfg.get('websocket_protocol') + '://'
         JBoxVol.USER_HOME_IMG = os.path.expanduser(JBoxCfg.get('user_home_image'))
         JBoxVol.PKG_IMG = os.path.expanduser(JBoxCfg.get('pkg_image'))
-        JBoxVol.BACKUP_LOC = backup_location
         JBoxVol.LOCAL_TZ_OFFSET = JBoxVol.local_time_offset()
         JBoxVol.BACKUP_BUCKET = JBoxCfg.get('cloud_host.backup_bucket')
 


### PR DESCRIPTION
Particularly useful during development or simple installations.

Mounts a subfolder from the host machine directly as the user home.
All of the host disk space usable by all users of JuliaBox.

JuliaBox user home backups can be optionally disabled, which allows for much
faster startups.

Also updated the installation documents to use this mode for single user / development setup.