### PR TITLE
make HTTP/WebSocket applications accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ The only constraint is imagination (and server cost).
 
 ## Features
 
-- Run [IJulia](https://github.com/JuliaLang/IJulia.jl) sessions
+- Run interactive sessions
+    - Run [IJulia](https://github.com/JuliaLang/IJulia.jl) notebooks.
     - A bash session is also started in the container, which can be used to run the Julia REPL.
+    - Run HTTP/WebSocket/[Escher](https://github.com/shashi/Escher.jl) applications in the container and access them over the browser.
     - File transfer facility into a session's container.
     - File synchronization with Google Drive.
     - Clone Github repositories.
@@ -26,6 +28,7 @@ The only constraint is imagination (and server cost).
 - Basic admin screen to delete old and inactive sessions.
 - Auto cleanup of sessions and API servers based on inactivity.
 - Ability to limit CPU, memory, and disk space for user sessions and APIs.
+- Extensible with plugins.
 
 ## Docs
 

--- a/container/interactive/Dockerfile
+++ b/container/interactive/Dockerfile
@@ -38,6 +38,7 @@ WORKDIR /home/juser
 # 4200: http port for console
 # 8000: http port for tornado
 # 8998: ipython port for julia
-EXPOSE  4200 8000 8998
+# 8050-8052: user specified applications
+EXPOSE  4200 8000 8998 8050 8051 8052
 
 ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/home/juser/.juliabox/supervisord.conf", "-l", "/home/juser/.juliabox/supervisord.log", "-j", "/home/juser/.juliabox/supervisord.pid", "-q", "/home/juser/.juliabox"]

--- a/engine/src/juliabox/jbox_container.py
+++ b/engine/src/juliabox/jbox_container.py
@@ -35,15 +35,13 @@ class BaseContainer(LoggerMixin):
         return self.props
 
     def _get_host_ports(self, ports):
-        if self.host_ports is None:
-            props = self.get_props()
-            cont_ports = props['NetworkSettings']['Ports']
-            port_map = []
-            for port in ports:
-                tcp_port = str(port) + '/tcp'
-                port_map.append(cont_ports[tcp_port][0]['HostPort'])
-            self.host_ports = tuple(port_map)
-        return self.host_ports
+        props = self.get_props()
+        cont_ports = props['NetworkSettings']['Ports']
+        port_map = []
+        for port in ports:
+            tcp_port = str(port) + '/tcp'
+            port_map.append(cont_ports[tcp_port][0]['HostPort'])
+        return tuple(port_map)
 
     def get_cpu_allocated(self):
         props = self.get_props()

--- a/engine/www/ipnbadmin.tpl
+++ b/engine/www/ipnbadmin.tpl
@@ -94,6 +94,16 @@
 	    	    parent.JuliaBox.websocktest();
 	    	});
 
+	    	$('#openport').click(function(event){
+	    	    event.preventDefault();
+	    		parent.JuliaBox.open_port();
+	    	});
+
+	    	$('#openedports').click(function(event){
+	    	    event.preventDefault();
+	    	    parent.JuliaBox.show_opened_ports();
+	    	});
+
 {% if (d["manage_containers"] or d["show_report"]) %}
 	    	$('#showuserstats').click(function(event){
 	    		event.preventDefault();
@@ -162,6 +172,7 @@
 	<tr><td>SSH Public Key:</td><td><a href="#" id="showsshkey">View</a></td></tr>
 	<tr><td>Julia Image:</td><td><span id='jimg_curr'>precompiled packages</span> (<a href="#" id="jimg_switch"><small>switch to: <span id='jimg_new'>standard</span></small></a>)</td></tr>
 	<tr><td>Network Connectivity Test:</td><td><a href="#" id="websocktest">Start</a></td></tr>
+	<tr><td>Application Ports:</td><td><a href="#" id="openedports">View</a> | <a href="#" id="openport">Open Another</a></td></tr>
 </table>
 
 <h3>JuliaBox version:</h3>

--- a/webserver/conf/nginx.conf.tpl
+++ b/webserver/conf/nginx.conf.tpl
@@ -68,6 +68,16 @@ http {
             include jbox_router.incl;
         }
 
+        location ~ "/jws_[a-zA-Z0-9_\-]{1,50}/.*" {
+            include jbox_router.incl;
+
+            # WebSocket support (nginx 1.4)
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout  600;
+        }
+
         location / {
             include jbox_router.incl;
 

--- a/webserver/scripts/router.lua
+++ b/webserver/scripts/router.lua
@@ -79,7 +79,7 @@ function M.rewrite_uri()
     local match
 
     ngx.log(ngx.DEBUG, "checking whether to rewrite uri: " .. uri)
-    match = ngx.re.match(uri, "^/jci_[a-zA-Z0-9_\\-]{1,50}/(.*)")
+    match = ngx.re.match(uri, "^/(?:jci|jws)_[a-zA-Z0-9_\\-]{1,50}/(.*)")
 
     if match then
         local rewriteuri = "/" .. (match[1] or "")
@@ -275,7 +275,7 @@ function M.jbox_route()
         return
     end
 
-    local match = ngx.re.match(uri, "^/jci_([a-zA-Z0-9_\\-]{1,50})/.*")
+    local match = ngx.re.match(uri, "^/(?:jci|jws)_([a-zA-Z0-9_\\-]{1,50})/.*")
     if match then
         local sessjson = M.forbid_invalid_session()
         local portname = match[1]

--- a/webserver/www/assets/js/juliabox.js
+++ b/webserver/www/assets/js/juliabox.js
@@ -123,6 +123,63 @@ var JuliaBox = (function($, _, undefined){
             return resp;
         },
 
+		open_port: function() {
+	    	s = function(res){
+	    	    if(res.code != 0) {
+	    	    	bootbox.alert("Error opening port. " + res.data);
+	    	    }
+	    	};
+
+			f = function() { bootbox.alert("Oops. Unexpected error while opening port.<br/><br/>Please try again later."); };
+
+			bootbox.dialog({
+				title: "Open a new port",
+				message: '<div class="row">  ' +
+					'<div class="col-md-12"> ' +
+                    '<form class="form-horizontal"> ' +
+                    '<div class="form-group"> ' +
+                    '<label class="col-md-4 control-label" for="portnum">Port</label> ' +
+                    '<div class="col-md-4"> ' +
+                    '<input id="portnum" name="portnum" type="text" placeholder="8050-8052" class="form-control input-md"> ' +
+                    '<span class="help-block">The port number to open</span> </div> ' +
+                    '</div> ' +
+                    '<div class="form-group"> ' +
+                    '<label class="col-md-4 control-label" for="portname">Alias</label> ' +
+                    '<div class="col-md-4"> ' +
+                    '<input id="portname" name="portname" type="text" placeholder="URL alias" class="form-control input-md"> ' +
+                    '<span class="help-block">The port will be accessible at /jci_&lt;alias&gt; as HTTP and /jcw_&lt;alias&gt; as websocket</span>. </div> ' +
+                    '</div> ' +
+                    '</form> </div>  </div>',
+                buttons: {
+                	success: {
+                		label: "Open",
+                		className: "btn-success",
+                		callback: function () {
+                			portnum = $('#portnum').val();
+                			portname = $('#portname').val();
+                			self.comm('/jboxadmin/', 'GET', {'open_port': portnum, 'port_name': portname}, s, f);
+                		}
+                	}
+                }
+			});
+		},
+
+		show_opened_ports: function() {
+			portnames = {}
+			for (var it in $.cookie()) {
+				if(it.indexOf("jp_") == 0) {
+					n = it.substring(3,it.length);
+					if(['shell', 'nb', 'file'].indexOf(n) == -1) {
+						portnames[n] = "/jci_" + n + " or /jws_" + n;
+					}
+				}
+			}
+			bootbox.dialog({
+				message: self._json_to_table(portnames),
+				title: "Ports"
+			}).find("div.modal-dialog").addClass("bootbox70");
+		},
+
         show_config: function() {
 	    	s = function(cfg){
 	    	    if(cfg.code == 0) {


### PR DESCRIPTION
Applications that communicate over HTTP or WebSockets can now
be invoked inside a JuliaBox session and accessed directly from
the browser.

TCP ports 8050-8052 from the container are proxied through a
user chosen alias over https://juliabox.org/jcw_<alias>/ (as websockets) or
as https://juliabox.org/jci_<alias>/ (as plain HTTP). The ports can be
opened and mapped to an alias from the JuliaBox settings tab.

JuliaBox plugins can also open ports transparently and provide a convenient
and seamless experience. Widely used applications may provide such plugins.