### PR TITLE
fix setup script. mention docker gid configuration

### DIFF
--- a/container/interactive/setup_julia.sh
+++ b/container/interactive/setup_julia.sh
@@ -30,7 +30,7 @@ do
     julia -e "Pkg.clone(\"$pkg\")"
 done
 
-if [[ $DEFAULT_PACKAGES == *" Interact "*]]
+if [[ $DEFAULT_PACKAGES == *" Interact "* ]]
 then
     echo "Checking out Interact package for IPython 3 compatibility"
     julia -e "Pkg.checkout(\"Interact\")"
@@ -67,7 +67,7 @@ do
     /opt/julia_nightly/bin/julia -e "Pkg.clone(\"$pkg\")"
 done
 
-if [[ $JULIA_NIGHTLY_DEFAULT_PACKAGES == *" Interact "*]]
+if [[ $JULIA_NIGHTLY_DEFAULT_PACKAGES == *" Interact "* ]]
 then
     echo "Checking out Interact package for IPython 3 compatibility"
     /opt/julia_nightly/bin/julia -e "Pkg.checkout(\"Interact\")"

--- a/docs/INSTALL.MD
+++ b/docs/INSTALL.MD
@@ -134,6 +134,7 @@ The following procedure will configure a system without authentication, designed
 		- Run `JuliaBox/scripts/install/img_create.sh home /jboxengine/data`
 	
 4. *JuliaBox services* Docker image creation.
+	- If gid of the docker group on the host machine is not 999 (the default on most systems), update `engine/Dockerfile.base` accordingly.
 	- Run `JuliaBox/scripts/install/img_create.sh jbox`
 
 5. JuliaBox database preperation


### PR DESCRIPTION
Fix missing whitespace in bash command that breaks script - #283

Docker installs itself with gid 999 on most systems. But installation breaks if it is not, and needs a change in Dockefile. Mentioned this in the installation document.