### PR TITLE
update to Julia v0.4.0-rc1, discontinue precompilation on v0.3

### DIFF
--- a/container/api/Dockerfile
+++ b/container/api/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox APIs
-# Version:34
+# Version:35
 
 FROM julialang/juliaboxpkgdist:v0.3.11
 
@@ -15,7 +15,7 @@ RUN groupadd juser \
 
 # add Julia nightly build
 RUN mkdir -p /opt/julia_0.4.0 && \
-    curl -s -L https://status.julialang.org/download/linux-x86_64 | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
+    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.0-rc1-linux-x86_64.tar.gz | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
 RUN ln -fs /opt/julia_0.4.0 /opt/julia_nightly
 
 USER juser

--- a/container/interactive/Dockerfile
+++ b/container/interactive/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox
-# Version:34
+# Version:35
 
 FROM julialang/juliaboxpkgdist:v0.3.11
 # Switching the base to the bare julia image helps during JuliaBox development by reducing image size
@@ -18,7 +18,7 @@ RUN groupadd juser \
 
 # add Julia nightly build
 RUN mkdir -p /opt/julia_0.4.0 && \
-    curl -s -L https://status.julialang.org/download/linux-x86_64 | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
+    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.0-rc1-linux-x86_64.tar.gz | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
 RUN ln -fs /opt/julia_0.4.0 /opt/julia_nightly
 
 # JuliaBox package bundle shall be mounted at /opt/julia_packages.

--- a/container/interactive/mk_user_home.sh
+++ b/container/interactive/mk_user_home.sh
@@ -23,17 +23,17 @@ sudo rm -rf ${PKG_DIR}
 mkdir -p ${JUSER_HOME}
 mkdir -p ${PKG_DIR}
 mkdir -p ${JUSER_HOME}/.juliabox
-mkdir -p ${PKG_DIR}/jimg/stable
-mkdir -p ${PKG_DIR}/jimg/nightly
+#mkdir -p ${PKG_DIR}/jimg/stable
+#mkdir -p ${PKG_DIR}/jimg/nightly
 
 cp ${DIR}/setup_julia.sh ${JUSER_HOME}
-cp ${DIR}/jimg.jl ${JUSER_HOME}
-cp ${DIR}/mkjimg.jl ${JUSER_HOME}
+#cp ${DIR}/jimg.jl ${JUSER_HOME}
+#cp ${DIR}/mkjimg.jl ${JUSER_HOME}
 
 sudo chown -R 1000:1000 ${JUSER_HOME}
 sudo chown -R 1000:1000 ${PKG_DIR}
 docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --entrypoint="/home/juser/setup_julia.sh" juliabox/juliabox:latest || error_exit "Could not run juliabox image"
-docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --user=root --workdir=/home/juser --entrypoint="julia" juliabox/juliabox:latest mkjimg.jl || error_exit "Could not run juliabox image"
+# docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --user=root --workdir=/home/juser --entrypoint="julia" juliabox/juliabox:latest mkjimg.jl || error_exit "Could not run juliabox image"
 
 ## precompilation fails mysteriously sometimes. retry a couple of times to rule out spurious errors
 #n=0
@@ -52,7 +52,7 @@ docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e 
 
 sudo chown -R 1000:1000 ${JUSER_HOME}
 sudo chown -R 1000:1000 ${PKG_DIR}
-${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh ${JUSER_HOME}/build_sysimg.jl ${JUSER_HOME}/jimg.jl ${JUSER_HOME}/mkjimg.jl
+${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh # ${JUSER_HOME}/build_sysimg.jl ${JUSER_HOME}/jimg.jl ${JUSER_HOME}/mkjimg.jl
 
 ${SUDO_JUSER} cp ${DIR}/IJulia/ipython_notebook_config.py ${JUSER_HOME}/.ipython/profile_default/ipython_notebook_config.py
 ${SUDO_JUSER} cp ${DIR}/IJulia/custom.css ${JUSER_HOME}/.ipython/profile_default/static/custom/custom.css

--- a/engine/src/juliabox/handlers/admin.py
+++ b/engine/src/juliabox/handlers/admin.py
@@ -38,16 +38,10 @@ class AdminHandler(JBoxHandler):
             return
         if self.handle_if_instance_info(is_admin):
             return
-        if self.handle_switch_julia_img(user):
-            return
         if self.handle_if_open_port(sessname, user_id):
             return
 
         juliaboxver, _upgrade_available = self.get_upgrade_available(cont)
-
-        jimg_type = 0
-        if user.has_resource_profile(JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP):
-            jimg_type = JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP
 
         expire = JBoxCfg.get('interactive.expire')
         d = dict(
@@ -62,26 +56,10 @@ class AdminHandler(JBoxHandler):
             cpu=cont.get_cpu_allocated(),
             disk=cont.get_disk_allocated(),
             expire=expire,
-            juliaboxver=juliaboxver,
-            jimg_type=jimg_type
+            juliaboxver=juliaboxver
         )
 
         self.rendertpl("ipnbadmin.tpl", d=d)
-
-    def handle_switch_julia_img(self, user):
-        switch_julia_img = self.get_argument('switch_julia_img', None)
-        if switch_julia_img is None:
-            return False
-        if user.has_resource_profile(JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP):
-            user.unset_resource_profile(JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP)
-            new_img_type = 0
-        else:
-            user.set_resource_profile(JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP)
-            new_img_type = JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP
-        user.save()
-        response = {'code': 0, 'data': new_img_type}
-        self.write(response)
-        return True
 
     def handle_if_show_cfg(self, is_allowed):
         show_cfg = self.get_argument('show_cfg', None)

--- a/engine/src/juliabox/vol/volmgr.py
+++ b/engine/src/juliabox/vol/volmgr.py
@@ -135,12 +135,12 @@ class VolMgr(LoggerMixin):
     @staticmethod
     def get_disk_for_user(email):
         VolMgr.log_debug("restoring disk for %s", email)
-        user = JBoxUserV2(email)
+        # user = JBoxUserV2(email)
 
         custom_jimg = None
         # TODO: image path should be picked up from config
-        if user.has_resource_profile(JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP):
-            custom_jimg = '/opt/julia_packages/jimg/stable/sys.ji'
+        # if user.has_resource_profile(JBoxUserV2.RES_PROF_JULIA_PKG_PRECOMP):
+        #     custom_jimg = '/opt/julia_packages/jimg/stable/sys.ji'
 
         plugin = JBoxVol.jbox_get_plugin(JBoxVol.JBP_USERHOME)
         if plugin is None:

--- a/engine/www/ipnbadmin.tpl
+++ b/engine/www/ipnbadmin.tpl
@@ -84,11 +84,6 @@
 	    		parent.JuliaBox.show_packages('nightly');
 	    	});
 
-	    	$('#jimg_switch').click(function(event){
-	    		event.preventDefault();
-	    		parent.JuliaBox.switch_julia_image($('#jimg_curr'), $('#jimg_new'));
-	    	});
-
 	    	$('#websocktest').click(function(event){
 	    	    event.preventDefault();
 	    	    parent.JuliaBox.websocktest();
@@ -144,7 +139,6 @@
 	    	});
 {% end %}
 
-            parent.JuliaBox.set_julia_image_type($('#jimg_curr'), $('#jimg_new'), {{d["jimg_type"]}});
 	    	$('#disp_date_init').html((new Date('{{d["created"]}}')).toLocaleString());
 	    	$('#disp_date_start').html((new Date('{{d["started"]}}')).toLocaleString());
 	    	$('#disp_date_allowed_till').html((new Date('{{d["allowed_till"]}}')).toLocaleString());
@@ -170,7 +164,6 @@
 	<tr><td>Allocated Memory:</td><td><span id='disp_mem'></span></td></tr>
 	<tr><td>Allocated CPUs:</td><td>{{d["cpu"]}}</td></tr>
 	<tr><td>SSH Public Key:</td><td><a href="#" id="showsshkey">View</a></td></tr>
-	<tr><td>Julia Image:</td><td><span id='jimg_curr'>precompiled packages</span> (<a href="#" id="jimg_switch"><small>switch to: <span id='jimg_new'>standard</span></small></a>)</td></tr>
 	<tr><td>Network Connectivity Test:</td><td><a href="#" id="websocktest">Start</a></td></tr>
 	<tr><td>Application Ports:</td><td><a href="#" id="openedports">View</a> | <a href="#" id="openport">Open Another</a></td></tr>
 </table>

--- a/webserver/www/assets/js/juliabox.js
+++ b/webserver/www/assets/js/juliabox.js
@@ -76,31 +76,6 @@ var JuliaBox = (function($, _, undefined){
 	    	self.comm('/jci_file/pkginfo', 'GET', {'ver': ver}, s, f);
 	    },
 
-	    switch_julia_image: function(disp_curr, disp_switch) {
-	    	s = function(img){
-	    	    if(img.code == 0) {
-	    	        self.set_julia_image_type(disp_curr, disp_switch, img.data);
-	    	        bootbox.alert('Your Julia image has been changed and will be effective the next time you log in.');
-	    	    }
-	    	    else {
-	    	        bootbox.alert("Oops. Unexpected error while switching Julia image.<br/><br/>Please try again later.");
-	    	    }
-	    	};
-	    	f = function() { bootbox.alert("Oops. Unexpected error while switching Julia image.<br/><br/>Please try again later."); };
-	    	self.comm('/jboxadmin/', 'GET', {'switch_julia_img': true}, s, f);
-	    },
-
-	    set_julia_image_type: function(disp_curr, disp_switch, curr_img_type) {
-	        if(0 == curr_img_type) {
-	            disp_curr.html("standard");
-	            disp_switch.html("precompiled packages");
-	        }
-	        else {
-	            disp_switch.html("standard");
-	            disp_curr.html("precompiled packages");
-	        }
-	    },
-
         _json_to_table: function(o) {
             resp = '<table class="table">';
             for(n in o) {


### PR DESCRIPTION
Update Julia 0.4 to the rc1 release.

And, do not precompile packages on Julia v0.3 anymore. Now that we have Julia v0.4 in a good shape with a much better precompilation model, we can stop what we have been doing on Julia v0.3.

It will avoid JuliaBox needing to touch the user's bashrc script and ipython profiles, which are problamatic when user disk is nearly full. Also, precompilation has been randomly problamatic recently. See #292