### PR TITLE
WIP: mount a host folder on api containers for logging

### DIFF
--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -34,7 +34,9 @@
         # Maximum number of requests in queue before rejecting new requests
         "numapilocalmax" : 5,
         # Seconds to wait before force deleting a non-responding container
-        "expire" : 1800
+        "expire" : 1800,
+        # Host folder where API containers can write logs. This is mounted as /home/juser/logs in the container.
+        "log_location" : "/jboxengine/logs/api"
     },
 
     # interactive container configuration


### PR DESCRIPTION
Needs some more elaboration:
- configure log folder and log file name for Julia through environment variables set on the container
- setup logging to point to the folder as specified in env (needs changes to JuliaWebAPI.jl)
- a mechanism to aggregate log files (CloudWatch in case of AWS) and display them to API publishers