### PR TITLE
update Julia version, packages & package handling

### DIFF
--- a/container/api/Dockerfile
+++ b/container/api/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox APIs
-# Version:36
+# Version:37
 
 FROM julialang/juliaboxpkgdist:v0.3.11
 
@@ -13,17 +13,27 @@ RUN groupadd juser \
     && useradd -m -d /home/juser -s /bin/bash -g juser -G staff juser \
     && echo "export HOME=/home/juser" >> /home/juser/.bashrc
 
-# add Julia nightly build
-RUN mkdir -p /opt/julia_0.4.0 && \
-    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.0-rc2-linux-x86_64.tar.gz | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
-RUN ln -fs /opt/julia_0.4.0 /opt/julia_nightly
+# link Julia v0.3
+RUN ln -fs /opt/julia_0.3.11 /opt/julia-0.3.11 && \
+    ln -fs /opt/julia-0.3.11 /opt/julia-0.3
+
+# add Julia v0.4 build
+RUN mkdir -p /opt/julia-0.4.0 && \
+    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.0-linux-x86_64.tar.gz | tar -C /opt/julia-0.4.0 -x -z --strip-components=1 -f -
+RUN ln -fs /opt/julia-0.4.0 /opt/julia-0.4
+
+# add Julia v0.5 nightly build
+RUN mkdir -p /opt/julia-0.5.0-dev && \
+    curl -s -L https://status.julialang.org/download/linux-x86_64 | tar -C /opt/julia-0.5.0-dev -x -z --strip-components=1 -f -
+RUN ln -fs /opt/julia-0.5.0-dev /opt/julia-0.5
 
 USER juser
 ENV HOME /home/juser
 ENV PATH /usr/local/texlive/2014/bin/x86_64-linux:/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin:/opt/julia/bin
 WORKDIR /home/juser
 
-RUN /opt/julia_0.4.0/bin/julia  -e "try; Pkg.installed(\"JuliaWebAPI\"); catch; Pkg.clone(\"https://github.com/tanmaykm/JuliaWebAPI.jl\"); end"
-RUN /opt/julia_0.3.11/bin/julia -e "try; Pkg.installed(\"JuliaWebAPI\"); catch; Pkg.clone(\"https://github.com/tanmaykm/JuliaWebAPI.jl\"); end"
+RUN /opt/julia-0.3/bin/julia  -e "try; Pkg.installed(\"JuliaWebAPI\"); catch; Pkg.clone(\"https://github.com/tanmaykm/JuliaWebAPI.jl\"); end"
+RUN /opt/julia-0.4/bin/julia  -e "try; Pkg.installed(\"JuliaWebAPI\"); catch; Pkg.clone(\"https://github.com/tanmaykm/JuliaWebAPI.jl\"); end"
+RUN /opt/julia-0.5/bin/julia  -e "try; Pkg.installed(\"JuliaWebAPI\"); catch; Pkg.clone(\"https://github.com/tanmaykm/JuliaWebAPI.jl\"); end"
 
 ENTRYPOINT ["julia", "-e", "using JuliaWebAPI; using Compat; process();"]

--- a/container/interactive/Dockerfile
+++ b/container/interactive/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox
-# Version:36
+# Version:37
 
 FROM julialang/juliaboxpkgdist:v0.3.11
 # Switching the base to the bare julia image helps during JuliaBox development by reducing image size
@@ -16,16 +16,26 @@ RUN groupadd juser \
     && useradd -m -d /home/juser -s /bin/bash -g juser -G staff juser \
     && echo "export HOME=/home/juser" >> /home/juser/.bashrc
 
-# add Julia nightly build
-RUN mkdir -p /opt/julia_0.4.0 && \
-    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.0-rc2-linux-x86_64.tar.gz | tar -C /opt/julia_0.4.0 -x -z --strip-components=1 -f -
-RUN ln -fs /opt/julia_0.4.0 /opt/julia_nightly
+# link Julia v0.3
+RUN ln -fs /opt/julia_0.3.11 /opt/julia-0.3.11 && \
+    ln -fs /opt/julia-0.3.11 /opt/julia-0.3
+
+# add Julia v0.4.0 build
+RUN mkdir -p /opt/julia-0.4.0 && \
+    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.0-linux-x86_64.tar.gz | tar -C /opt/julia-0.4.0 -x -z --strip-components=1 -f -
+RUN ln -fs /opt/julia-0.4.0 /opt/julia-0.4
+
+# add Julia v0.5 nightly build
+RUN mkdir -p /opt/julia-0.5.0-dev && \
+    curl -s -L https://status.julialang.org/download/linux-x86_64 | tar -C /opt/julia-0.5.0-dev -x -z --strip-components=1 -f -
+RUN ln -fs /opt/julia-0.5.0-dev /opt/julia-0.5
 
 # JuliaBox package bundle shall be mounted at /opt/julia_packages.
 # They are added to LOAD_PATH through respective juliarc.jl scripts.
 RUN mkdir /opt/julia_packages
-RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.4/")' >> /opt/julia_0.4.0/etc/julia/juliarc.jl
-RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/")' >> /opt/julia_0.3.11/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.5/")' >> /opt/julia-0.5/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.4/")' >> /opt/julia-0.4/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/")' >> /opt/julia-0.3/etc/julia/juliarc.jl
 
 # Data volumes shall be mounted at /mnt/data
 RUN mkdir /mnt/data

--- a/container/interactive/IJulia/ipython_notebook_config.py
+++ b/container/interactive/IJulia/ipython_notebook_config.py
@@ -1,5 +1,6 @@
 c = get_config()
 c.NotebookApp.port = 8998
 c.NotebookApp.open_browser = False
+c.KernelRestarter.time_to_dead = 6.0
 c.NotebookApp.ip = "*"
 c.NotebookApp.allow_origin = "*"

--- a/container/interactive/mk_user_home.sh
+++ b/container/interactive/mk_user_home.sh
@@ -23,36 +23,16 @@ sudo rm -rf ${PKG_DIR}
 mkdir -p ${JUSER_HOME}
 mkdir -p ${PKG_DIR}
 mkdir -p ${JUSER_HOME}/.juliabox
-#mkdir -p ${PKG_DIR}/jimg/stable
-#mkdir -p ${PKG_DIR}/jimg/nightly
 
 cp ${DIR}/setup_julia.sh ${JUSER_HOME}
-#cp ${DIR}/jimg.jl ${JUSER_HOME}
-#cp ${DIR}/mkjimg.jl ${JUSER_HOME}
 
 sudo chown -R 1000:1000 ${JUSER_HOME}
 sudo chown -R 1000:1000 ${PKG_DIR}
 docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --entrypoint="/home/juser/setup_julia.sh" juliabox/juliabox:latest || error_exit "Could not run juliabox image"
-# docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --user=root --workdir=/home/juser --entrypoint="julia" juliabox/juliabox:latest mkjimg.jl || error_exit "Could not run juliabox image"
-
-## precompilation fails mysteriously sometimes. retry a couple of times to rule out spurious errors
-#n=0
-#until [ $n -ge 3 ]
-#do
-#    docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --user=root --workdir=/home/juser --entrypoint="julia" juliabox/juliabox:latest mkjimg.jl && break
-#    echo "Building image failed. Will retry."
-#    n=$[$n+1]
-#    sleep 10
-#done
-#
-#if [ $n -ge 3 ]
-#then
-#    error_exit "Could not run juliabox image"
-#fi
 
 sudo chown -R 1000:1000 ${JUSER_HOME}
 sudo chown -R 1000:1000 ${PKG_DIR}
-${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh # ${JUSER_HOME}/build_sysimg.jl ${JUSER_HOME}/jimg.jl ${JUSER_HOME}/mkjimg.jl
+${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh
 
 ${SUDO_JUSER} cp ${DIR}/IJulia/ipython_notebook_config.py ${JUSER_HOME}/.ipython/profile_default/ipython_notebook_config.py
 ${SUDO_JUSER} cp ${DIR}/IJulia/custom.css ${JUSER_HOME}/.ipython/profile_default/static/custom/custom.css
@@ -66,10 +46,10 @@ ${SUDO_JUSER} cp ${DIR}/IJulia/supervisord.conf ${JUSER_HOME}/.juliabox/supervis
 ${SUDO_JUSER} cp -R ${DIR}/IJulia/tutorial ${JUSER_HOME}/.juliabox/tutorial
 
 sudo rm ${DATA_LOC}/julia_packages.tar.gz
-sudo tar -czvf ${DATA_LOC}/julia_packages.tar.gz -C ${PKG_DIR} .
+sudo tar -czf ${DATA_LOC}/julia_packages.tar.gz -C ${PKG_DIR} .
 
 sudo rm ${DATA_LOC}/user_home.tar.gz
-sudo tar -czvf ${DATA_LOC}/user_home.tar.gz -C ${JUSER_HOME} .
+sudo tar -czf ${DATA_LOC}/user_home.tar.gz -C ${JUSER_HOME} .
 
 sudo rm -rf ${JUSER_HOME}
 sudo rm -rf ${PKG_DIR}

--- a/engine/src/juliabox/vol/jbox_volume.py
+++ b/engine/src/juliabox/vol/jbox_volume.py
@@ -287,20 +287,20 @@ class JBoxVol(LoggerMixin):
         os.remove(filepath_temp)
 
     def setup_julia_image(self, custom_jimg):
-        # switch profile in kernel.json
-        # this hack should not be required once we move completely to Julia 0.4
-        kernel_path = os.path.join(self.disk_path, ".ipython", "kernels", "julia-0.3", "kernel.json")
-        kernel_cfg = {
-            "argv": ["/usr/bin/julia"],
-            "display_name": "Julia 0.3.11",
-            "language": "julia"
-        }
-
-        if custom_jimg is not None:
-            kernel_cfg['argv'].extend(["-J", custom_jimg])
-        kernel_cfg['argv'].extend(["-i", "-F", "/opt/julia_packages/.julia/v0.3/IJulia/src/kernel.jl", "{connection_file}"])
-        with open(kernel_path, 'w') as kout:
-            kout.write(json.dumps(kernel_cfg, indent=4))
+        # # switch profile in kernel.json
+        # # this hack should not be required once we move completely to Julia 0.4
+        # kernel_path = os.path.join(self.disk_path, ".ipython", "kernels", "julia-0.3", "kernel.json")
+        # kernel_cfg = {
+        #     "argv": ["/usr/bin/julia"],
+        #     "display_name": "Julia 0.3.11",
+        #     "language": "julia"
+        # }
+        #
+        # if custom_jimg is not None:
+        #     kernel_cfg['argv'].extend(["-J", custom_jimg])
+        # kernel_cfg['argv'].extend(["-i", "-F", "/opt/julia_packages/.julia/v0.3/IJulia/src/kernel.jl", "{connection_file}"])
+        # with open(kernel_path, 'w') as kout:
+        #     kout.write(json.dumps(kernel_cfg, indent=4))
 
         # add/remove alias in .bashrc
         bashrc_path = os.path.join(self.disk_path, ".bashrc")

--- a/engine/www/ipnbadmin.tpl
+++ b/engine/www/ipnbadmin.tpl
@@ -74,15 +74,15 @@
 	    		parent.JuliaBox.show_ssh_key();
 	    	});
 
-	    	$('#showpackagesstable').click(function(event){
-	    		event.preventDefault();
-	    		parent.JuliaBox.show_packages('stable');
-	    	});
+            $('.showpackages').click(function(event) {
+            	tid = event.target.id;
+            	ver = tid.split('-')[1]
+	    		parent.JuliaBox.show_packages(ver);
+            });
 
-	    	$('#showpackagesnightly').click(function(event){
-	    		event.preventDefault();
-	    		parent.JuliaBox.show_packages('nightly');
-	    	});
+            $('#delpackages').click(function(event) {
+	    		parent.JuliaBox.del_packages_confirm();
+            });
 
 	    	$('#websocktest').click(function(event){
 	    	    event.preventDefault();
@@ -170,7 +170,12 @@
 
 <h3>JuliaBox version:</h3>
 JuliaBox version: {{d["juliaboxver"]}} <br/>
-Julia versions and packages: <a href="#" id="showpackagesstable">stable</a> | <a href="#" id="showpackagesnightly">nightly</a><br/>
+Julia versions and packages: <a href="#" class="showpackages" id="showpackages-0.3">0.3</a> | <a href="#" class="showpackages" id="showpackages-0.4">0.4</a> | <a href="#" class="showpackages" id="showpackages-0.5">0.5</a><br/>
+<p>
+	<br/>
+	Note: A conflict between system packages those installed by you may cause errors and failures while starting notebooks.<br/>
+	In such cases, delete/update conflicting packages or <a href="#" id="delpackages">click here</a> to go back to using system installed packages only.<br/>
+</p>
 <br/>
 
 {% include "../../../www/admin_modules.tpl" %}

--- a/webserver/www/assets/js/juliabox.js
+++ b/webserver/www/assets/js/juliabox.js
@@ -76,6 +76,27 @@ var JuliaBox = (function($, _, undefined){
 	    	self.comm('/jci_file/pkginfo', 'GET', {'ver': ver}, s, f);
 	    },
 
+	    del_packages_confirm: function() {
+			self.popup_confirm("Switch back to system installed packages? Your local packages folder (~/.julia) will be renamed.", function(res) {
+				if(res) {
+					self.del_packages();
+				}
+			});
+		},
+
+	    del_packages: function() {
+	    	s = function(renamedto){
+	    		if(renamedto.data.length > 0) {
+	    			bootbox.alert('Your locally installed packages are moved into the "' + renamedto.data + '" folder. You will be using system provided packages from now on.');
+	    		}
+	    		else {
+	    			bootbox.alert('You are using system provided packages already.');
+	    		}
+	    	};
+	    	f = function() { bootbox.alert("Oops. Unexpected error while renaming your packages folder.<br/><br/>Please try again later."); };
+	    	self.comm('/jci_file/pkgreset', 'GET', null, s, f);
+	    },
+
         _json_to_table: function(o) {
             resp = '<table class="table">';
             for(n in o) {


### PR DESCRIPTION
- update Julia 0.4.0-rc2 to 0.4.0
- add Julia 0.5.0-dev
- add message explaining conflict between system provided and user installed packages
- provide button fix conflicts by deleting user installed packages (actually by renaming .julia)
- increase Jupyter `KernelRestarter.time_to_dead` from 3 to 6

Failure to start notebooks are most certainly due to package conflicts. The only way to resolve them is to update local packages to acceptable versions. There's a button in the settings page now to rename `~/.julia` to a temporary folder which should resolve this issue for most cases.

Jupyter restarts the kernel when it fails to start. There's a check to prevent endless restarts, but that kicks in only if kernel restarts in less than 3 secs. That's too small in some cases and causes IJulia to be restarted infinitely, taking up 100% of a CPU core and filling up the disk with logs.

Too many of such runaway processes can saturate the host machine, both in terms of CPU and disk IO.

I am now changing it to 6 based on some local tests. (But that still can break either ways. Jupyter KernelRestarter probably needs a better mechanism. Needs to be looked at separately.)

fixes #306