### PR TITLE
simple status page hosted on S3

### DIFF
--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -75,6 +75,7 @@
 
     	# Configure names for tables and buckets
 	    "backup_bucket": "juliabox-userbackup",
+        "status_bucket": "juliabox-status",
 
 	    # EBS disk template snapshot id
 	    "ebs_template": None,


### PR DESCRIPTION
Cluster leader updates a S3 hosted static page on each maintenance cycle (once in 5 minutes).
Reports load for all active machines in cluster, and any dead nodes.
Dead machines should be automatically removed and replaced with new ones.

JuliaBox status can be considered as not green if any of the following is true:
- status not updated for more than 10 minutes
- machines consistently appear dead
- status page itself is not accessible (indicating Amazon S3 is not accessible)
- AWS status page shows disruptions

fixes #304