### PR TITLE
ulimits for docker container, shellinabox, Julia

### DIFF
--- a/container/interactive/Dockerfile
+++ b/container/interactive/Dockerfile
@@ -33,12 +33,14 @@ RUN ln -fs /opt/julia-0.5.0-dev /opt/julia-0.5
 # JuliaBox package bundle shall be mounted at /opt/julia_packages.
 # They are added to LOAD_PATH through respective juliarc.jl scripts.
 RUN mkdir /opt/julia_packages
-RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.5/")' >> /opt/julia-0.5/etc/julia/juliarc.jl
-RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.4/")' >> /opt/julia-0.4/etc/julia/juliarc.jl
-RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/")' >> /opt/julia-0.3/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.5/"); try using JuliaBoxUtils; JuliaBoxUtils.SysLim.setrlimit(JuliaBoxUtils.SysLim.RLIMIT_NOFILE, 256) end' >> /opt/julia-0.5/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.4/"); try using JuliaBoxUtils; JuliaBoxUtils.SysLim.setrlimit(JuliaBoxUtils.SysLim.RLIMIT_NOFILE, 256) end' >> /opt/julia-0.4/etc/julia/juliarc.jl
+RUN echo 'push!(LOAD_PATH, "/opt/julia_packages/.julia/v0.3/"); try using JuliaBoxUtils; JuliaBoxUtils.SysLim.setrlimit(JuliaBoxUtils.SysLim.RLIMIT_NOFILE, 256) end' >> /opt/julia-0.3/etc/julia/juliarc.jl
 
 # Data volumes shall be mounted at /mnt/data
 RUN mkdir /mnt/data
+
+RUN echo "ulimit -u 2048 -n 256" >> /etc/bash.bashrc
 
 USER juser
 ENV HOME /home/juser

--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -34,7 +34,9 @@
         # Maximum number of requests in queue before rejecting new requests
         "numapilocalmax" : 5,
         # Seconds to wait before force deleting a non-responding container
-        "expire" : 1800
+        "expire" : 1800,
+        # ulimit for container, set as both hard and soft limit
+        "ulimits" : { "nofile": 1024 }
     },
 
     # interactive container configuration
@@ -52,7 +54,9 @@
         # Seconds to wait before clearing an inactive session, for example, when the user closes the browser window
         "inactivity_timeout" : 300,
         # Upper time limit for a user session before it is auto-deleted. 0 means never expire
-        "expire" : 0
+        "expire" : 0,
+        # ulimit for container, set as both hard and soft limit
+        "ulimits" : { "nofile": 1024 }
     },
 
     # if using Google auth, the API key and secret to use

--- a/engine/src/juliabox/api/api_container.py
+++ b/engine/src/juliabox/api/api_container.py
@@ -5,6 +5,7 @@ import hashlib
 import datetime
 import pytz
 import docker.utils
+from docker.utils import Ulimit
 
 from juliabox.jbox_container import BaseContainer
 from juliabox.jbox_util import JBoxCfg
@@ -23,6 +24,8 @@ class APIContainer(BaseContainer):
     # A group with 100 shares will get a ~10% portion of the CPU time (https://wiki.archlinux.org/index.php/Cgroups)
     CPU_LIMIT = 1024
     MEM_LIMIT = None
+    ULIMITS = None
+
     EXPIRE_SECS = 0
     MAX_CONTAINERS = 0
     MAX_PER_API_CONTAINERS = 0
@@ -40,6 +43,12 @@ class APIContainer(BaseContainer):
         BaseContainer.DCKR = JBoxCfg.dckr
         APIContainer.DCKR_IMAGE = JBoxCfg.get('api.docker_image')
         APIContainer.MEM_LIMIT = JBoxCfg.get('api.mem_limit')
+
+        APIContainer.ULIMITS = []
+        limits = JBoxCfg.get('interactive.ulimits')
+        for (n, v) in limits.iteritems():
+            APIContainer.ULIMITS.append(Ulimit(name=n, soft=v, hard=v))
+
         APIContainer.CPU_LIMIT = JBoxCfg.get('api.cpu_limit')
         APIContainer.MAX_CONTAINERS = JBoxCfg.get('api.numlocalmax')
         APIContainer.MAX_PER_API_CONTAINERS = JBoxCfg.get('api.numapilocalmax')


### PR DESCRIPTION
This provides a way to control system rlimits on user processes running inside docker container.
Dockerfile sets the hard limit, systemwide `.juliarc` sets limits for IJulia and commandline `julia`, and systemwide `.bashrc` sets limits for shellinabox.