### PR TITLE
tweaks for load distribution, error recovery, installation instructions

### DIFF
--- a/docs/INSTALL.MD
+++ b/docs/INSTALL.MD
@@ -89,6 +89,8 @@ The following procedure will configure a system without authentication, designed
 	- Create work folders:
 		- Execute `sudo mkdir -p /jboxengine/conf /jboxengine/data/db /jboxengine/data/disks/host`.
 		- Take ownership `sudo chown -R $USER: /jboxengine`.
+	- Ensure that the system is accessible on the browser with a FQDN that it resolves to from within the machine
+		- This typically needs an appropriate entry in the system `hosts` file.
 
 
 2. JuliaBox configuration.

--- a/engine/src/juliabox/srvr_jboxd.py
+++ b/engine/src/juliabox/srvr_jboxd.py
@@ -364,6 +364,7 @@ class JBoxd(LoggerMixin):
 
         if VolMgr.has_update_for_user_home_image():
             VolMgr.update_user_home_image(fetch=False)
+            VolMgr.refresh_user_home_image()
 
         while True:
             self.log_debug("JBox daemon waiting for commands...")


### PR DESCRIPTION
- reduce idle instance time to 50 minutes
- tweak load distribution to tighten machine allocation, prevent thrashing
- refresh disks and packages on a daemon restart (since unlike a fresh start, this will not be triggered by container managers)
- mention in the installation document that a single node setup requires a FQDN when it's not `localhost` (for websockets. ref: #14)