### PR TITLE
Julia update and other fixes

### DIFF
--- a/container/api/Dockerfile
+++ b/container/api/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox APIs
-# Version:38
+# Version:39
 
 FROM julialang/juliaboxpkgdist:v0.3.12
 
@@ -18,9 +18,9 @@ RUN ln -fs /opt/julia_0.3.12 /opt/julia-0.3.12 && \
     ln -fs /opt/julia-0.3.12 /opt/julia-0.3
 
 # add Julia v0.4 build
-RUN mkdir -p /opt/julia-0.4.1 && \
-    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.1-linux-x86_64.tar.gz | tar -C /opt/julia-0.4.1 -x -z --strip-components=1 -f -
-RUN ln -fs /opt/julia-0.4.1 /opt/julia-0.4
+RUN mkdir -p /opt/julia-0.4.2 && \
+    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.2-linux-x86_64.tar.gz | tar -C /opt/julia-0.4.2 -x -z --strip-components=1 -f -
+RUN ln -fs /opt/julia-0.4.2 /opt/julia-0.4
 
 # add Julia v0.5 nightly build
 RUN mkdir -p /opt/julia-0.5.0-dev && \

--- a/container/interactive/Dockerfile
+++ b/container/interactive/Dockerfile
@@ -1,5 +1,5 @@
 # Docker file for JuliaBox
-# Version:38
+# Version:39
 
 FROM julialang/juliaboxpkgdist:v0.3.12
 # Switching the base to the bare julia image helps during JuliaBox development by reducing image size
@@ -23,10 +23,10 @@ RUN groupadd juser \
 RUN ln -fs /opt/julia_0.3.12 /opt/julia-0.3.12 && \
     ln -fs /opt/julia-0.3.12 /opt/julia-0.3
 
-# add Julia v0.4.1 build
-RUN mkdir -p /opt/julia-0.4.1 && \
-    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.1-linux-x86_64.tar.gz | tar -C /opt/julia-0.4.1 -x -z --strip-components=1 -f -
-RUN ln -fs /opt/julia-0.4.1 /opt/julia-0.4
+# add Julia v0.4.2 build
+RUN mkdir -p /opt/julia-0.4.2 && \
+    curl -s -L https://julialang.s3.amazonaws.com/bin/linux/x64/0.4/julia-0.4.2-linux-x86_64.tar.gz | tar -C /opt/julia-0.4.2 -x -z --strip-components=1 -f -
+RUN ln -fs /opt/julia-0.4.2 /opt/julia-0.4
 
 # add Julia v0.5 nightly build
 RUN mkdir -p /opt/julia-0.5.0-dev && \

--- a/container/interactive/setup_julia.sh
+++ b/container/interactive/setup_julia.sh
@@ -14,7 +14,10 @@ function include_packages {
         echo ""
         echo "$METHOD package $PKG to Julia $JULIA_VER ..."
         /opt/julia-${JULIA_VER}/bin/julia -e "Pkg.${METHOD}(\"$PKG\")"
-        /opt/julia-${JULIA_VER}/bin/julia -e "Pkg.build(\"$PKG\")"
+        if [ ${METHOD} == "add" ]
+        then
+            /opt/julia-${JULIA_VER}/bin/julia -e "Pkg.build(\"$PKG\")"
+        fi
     done
 }
 
@@ -34,10 +37,9 @@ Optim JuMP GLPKMathProgInterface Clp NLopt Ipopt \
 Cairo GraphViz \
 Images ImageView WAV ODE Sundials LinearLeastSquares \
 BayesNets PGFPlots GraphLayout \
-Stan Patchwork Quandl Lazy QuantEcon MixedModels Escher"
+Stan Patchwork Quandl Lazy QuantEcon MixedModels Escher JuliaWebAPI"
 
 INTERNAL_PACKAGES="https://github.com/tanmaykm/JuliaBoxUtils.jl.git \
-https://github.com/tanmaykm/JuliaWebAPI.jl.git \
 https://github.com/shashi/Homework.jl.git"
 
 init_packages "0.3"
@@ -49,7 +51,6 @@ list_packages "0.3"
 DEFAULT_PACKAGES="IJulia"
 
 INTERNAL_PACKAGES="https://github.com/tanmaykm/JuliaBoxUtils.jl.git \
-https://github.com/tanmaykm/JuliaWebAPI.jl.git \
 https://github.com/shashi/Homework.jl.git"
 
 for ver in 0.4 0.5

--- a/engine/Dockerfile.base
+++ b/engine/Dockerfile.base
@@ -47,7 +47,6 @@ RUN pip install tornado \
     boto \
     pycrypto \
     psutil \
-    cli53 \
     sh \
     pyzmq \
     docker-py

--- a/engine/src/juliabox/srvr_jbox.py
+++ b/engine/src/juliabox/srvr_jbox.py
@@ -1,12 +1,12 @@
 import socket
 import signal
 import datetime
-import tempfile
 import os
 
 import tornado.ioloop
 import tornado.web
 import tornado.auth
+from tornado.httpclient import AsyncHTTPClient
 
 from cloud import Compute, JBPluginCloud
 import db
@@ -56,6 +56,9 @@ class JBox(LoggerMixin):
         self.log_info("Container maintenance every " + str(run_interval / (60 * 1000)) + " minutes")
         self.ct = tornado.ioloop.PeriodicCallback(JBox.do_housekeeping, run_interval, self.ioloop)
         self.sigct = tornado.ioloop.PeriodicCallback(JBox.do_signals, 1000, self.ioloop)
+
+        # or configure cacerts
+        AsyncHTTPClient.configure(None, defaults=dict(validate_cert=None))
 
     @staticmethod
     def get_pluggedin_features():


### PR DESCRIPTION
- update to Julia 0.4.2.
- `cli53` library is now pulled out. Excluded from dockerfile and not used internally anymore.
- do not build cloned packages, as build throws errors and occasionally segfaults.
- disable httpclient cert check (include cacerts in future)