### PR TITLE
Fix Typo in Calling C and Python.ipynb

### DIFF
--- a/container/interactive/IJulia/tutorial/Calling C and Python.ipynb
+++ b/container/interactive/IJulia/tutorial/Calling C and Python.ipynb
@@ -212,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Thanks to a package called `PyCall`, Julia **call arbitrary Python** functions by calling directly into CPython's `libpython`:"
+    "Thanks to a package called `PyCall`, Julia can **call arbitrary Python** functions by calling directly into CPython's `libpython`:"
    ]
   },
   {


### PR DESCRIPTION
Fixed typo in text above In[8]: missing "can".