### PR TITLE
Fixes for google plugins

### DIFF
--- a/container/interactive/mk_user_home.sh
+++ b/container/interactive/mk_user_home.sh
@@ -12,6 +12,7 @@ PKG_DIR=/tmp/jpkg
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #SUDO_JUSER="sudo -u#1000 -g#1000"
 SUDO_JUSER=""
+IDS=1000:1000
 
 function error_exit {
 	echo "$1" 1>&2
@@ -26,12 +27,12 @@ mkdir -p ${JUSER_HOME}/.juliabox
 
 cp ${DIR}/setup_julia.sh ${JUSER_HOME}
 
-sudo chown -R 1000:1000 ${JUSER_HOME}
-sudo chown -R 1000:1000 ${PKG_DIR}
+sudo chown -R ${IDS} ${JUSER_HOME}
+sudo chown -R ${IDS} ${PKG_DIR}
 docker run -i -v ${JUSER_HOME}:/home/juser -v ${PKG_DIR}:/opt/julia_packages -e "JULIA_PKGDIR=/opt/julia_packages/.julia" --entrypoint="/home/juser/setup_julia.sh" juliabox/juliabox:latest || error_exit "Could not run juliabox image"
 
-sudo chown -R 1000:1000 ${JUSER_HOME}
-sudo chown -R 1000:1000 ${PKG_DIR}
+sudo chown -R ${IDS} ${JUSER_HOME}
+sudo chown -R ${IDS} ${PKG_DIR}
 ${SUDO_JUSER} rm ${JUSER_HOME}/setup_julia.sh
 
 ${SUDO_JUSER} cp ${DIR}/IJulia/ipython_notebook_config.py ${JUSER_HOME}/.ipython/profile_default/ipython_notebook_config.py

--- a/engine/src/juliabox/plugins/bucket_gs/impl_gs.py
+++ b/engine/src/juliabox/plugins/bucket_gs/impl_gs.py
@@ -5,9 +5,10 @@ import urllib
 import io
 from juliabox.cloud import JBPluginCloud
 from juliabox.jbox_util import JBoxCfg
-from oauth2client.service_account import _ServiceAccountCredentials
+from oauth2client.client import GoogleCredentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
+from googleapiclient.errors import HttpError
 from mimetypes import MimeTypes
 
 class JBoxGS(JBPluginCloud):
@@ -18,13 +19,7 @@ class JBoxGS(JBPluginCloud):
     @staticmethod
     def connect():
         if JBoxGS.CONN is None:
-            google_oauth = JBoxCfg.get("google_oauth")
-            creds = _ServiceAccountCredentials(
-                service_account_id=google_oauth["client_id"],
-                service_account_email=google_oauth["client_email"],
-                private_key_id=google_oauth["key"],
-                private_key_pkcs8_text=google_oauth["secret"],
-                scopes=[])
+            creds = GoogleCredentials.get_application_default()
             JBoxGS.CONN = build("storage", "v1", credentials=creds)
         return JBoxGS.CONN
 

--- a/engine/src/juliabox/plugins/bucket_gs/info.md
+++ b/engine/src/juliabox/plugins/bucket_gs/info.md
@@ -1,6 +1,6 @@
 # Google Cloud Storage plugin
 
-To use Google cloud storage requires an OAuth2.0 Service Account.  Fill in the following parametes in `/jboxengine/conf/jbox.user` :
+Fill in the following parametes in `/jboxengine/conf/jbox.user` :
 
 ```python
 {
@@ -10,13 +10,6 @@ To use Google cloud storage requires an OAuth2.0 Service Account.  Fill in the f
         # ...
         "juliabox.plugins.bucket_gs",
     ],
-
-    "google_oauth": {
-        "key": "<the private key ID>",
-        "secret": "<the private key>",
-        "client_email": "<service account email>",
-        "client_id": "<service account ID>",
-    },
 
     "cloud_host": {
         # ...

--- a/engine/src/juliabox/plugins/db_cloudsql/__init__.py
+++ b/engine/src/juliabox/plugins/db_cloudsql/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'Nishanth'
-from impl_datastore import JBoxDatastore
+from impl_cloudsql import JBoxCloudSQL

--- a/engine/src/juliabox/plugins/db_cloudsql/info.md
+++ b/engine/src/juliabox/plugins/db_cloudsql/info.md
@@ -1,10 +1,8 @@
 # Google Cloud SQL
 
-Pull the cloudsql proxy docker image:
+Uncomment the line `# configure_cloudsql` in `scripts/install/sys_install.sh` and run it.
 
-```
-> docker pull b.gcr.io/cloudsql-docker/gce-proxy
-```
+Uncomment the block `[program:cloudsqlproxy]` from `host/supervisord.conf`.
 
 Add the following to `/jboxengine/conf/jbox.user`:
 
@@ -16,5 +14,3 @@ Add the following to `/jboxengine/conf/jbox.user`:
     'db': 'JuliaBox'
 }
 ```
-
-Uncomment the `[program:cloudsqlproxy]` part of `host/supervisord.conf`.

--- a/host/supervisord.conf
+++ b/host/supervisord.conf
@@ -59,5 +59,12 @@ stderr_logfile_backups = 2
 stderr_logfile_maxbytes = 1MB
 
 # [program:cloudsqlproxy]
-# command = docker run --rm --name=cloudsqlproxy -v /cloudsql:/cloudsql   -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt   b.gcr.io/cloudsql-docker/gce-proxy /cloud_sql_proxy -dir=/cloudsql   -instances=jc-test1:us-central1-c:juliasql
+# command = docker run --rm --name=cloudsqlproxy_jboxsvc -v /cloudsql:/cloudsql   -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt   b.gcr.io/cloudsql-docker/gce-proxy /cloud_sql_proxy -dir=/cloudsql   -instances=jc-test1:us-central1-c:juliasql		
+# directory =  %(here)s/../engine
 # process_name = cloudsqlproxy
+# stdout_logfile = %(here)s/../engine/logs/cloudsqlproxy.log
+# stdout_logfile_backups = 2
+# stdout_logfile_maxbytes = 1MB
+# stderr_logfile = %(here)s/../engine/logs/cloudsqlproxy_err.log
+# stderr_logfile_backups = 2
+# stderr_logfile_maxbytes = 1MB

--- a/scripts/install/create_tables_cloudsql.py
+++ b/scripts/install/create_tables_cloudsql.py
@@ -47,10 +47,14 @@ def indexes_create(table_name, indexes):
 
 def get_connection():
     # Copy from /jboxengine/conf/jbox.user
-    user = 'user'
-    passwd = 'passwd'
-    unix_socket = '/cloudsql/project:region:sqlinstance'
-    db = 'JuliaBox'
+    conf = None
+    with open('/jboxengine/conf/jbox.user') as f:
+        conf = eval(f.read())
+    db = conf['db']
+    user = db['user']
+    passwd = db['passwd']
+    unix_socket = db['unix_socket']
+    db = db['db']
     return MySQLdb.connect(user=user, passwd=passwd, db=db, unix_socket=unix_socket)
 
 conn = get_connection()

--- a/scripts/install/img_create.sh
+++ b/scripts/install/img_create.sh
@@ -69,7 +69,7 @@ function make_user_home {
 function print_usage {
     echo "Usage:"
     echo "Build JulaiBox components: img_create.sh jbox"
-    echo "Build/Pull JulaiBox containers: img_create.sh cont <build | pull>"
+    echo "Build/Pull JuliaBox containers: img_create.sh cont <build | pull>"
     echo "Build pkg bundle and user home image: img_create.sh home <data_location>"
 }
 

--- a/scripts/install/sys_install.sh
+++ b/scripts/install/sys_install.sh
@@ -26,7 +26,7 @@ function sysinstall_pystuff {
 function sysinstall_libs {
     # Stuff required for docker, and tornado
     sudo apt-get -y update
-    sudo apt-get -y install build-essential libreadline-dev libncurses-dev libpcre3-dev libssl-dev netcat git python-setuptools supervisor python-dev python-isodate python-pip python-tz libzmq-dev
+    sudo apt-get -y install build-essential libreadline-dev libncurses-dev libpcre3-dev libssl-dev netcat git python-setuptools supervisor python-dev python-isodate python-pip python-tz libzmq-dev libmysqlclient-dev
 }
 
 function sysinstall_docker {
@@ -60,10 +60,17 @@ function configure_docker {
     sleep 1
 }
 
+function configure_cloudsql {
+    docker pull b.gcr.io/cloudsql-docker/gce-proxy
+    sudo mkdir /cloudsql
+    sudo chmod 777 /cloudsql
+}
+
 sysinstall_libs
 sysinstall_docker
 sysinstall_pystuff
 configure_docker
+# configure_cloudsql           # Uncomment if using Google CloudSQL
 echo
 echo "DONE!"
  


### PR DESCRIPTION
Running `cloud_sql_proxy` as a process outside docker because the docker instance `cloud_sql_proxy` was being removed by `backup_and_cleanup`. (+ other minor fixes)