### PR TITLE
retry decorator for google plugins

### DIFF
--- a/engine/src/juliabox/plugins/bucket_gs/impl_gs.py
+++ b/engine/src/juliabox/plugins/bucket_gs/impl_gs.py
@@ -4,7 +4,7 @@ import os
 import urllib
 import io
 from juliabox.cloud import JBPluginCloud
-from juliabox.jbox_util import JBoxCfg, retry_on_bsl
+from juliabox.jbox_util import JBoxCfg
 from oauth2client.client import GoogleCredentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
@@ -29,7 +29,6 @@ class JBoxGS(JBPluginCloud):
         return JBoxGS.CONN
 
     @staticmethod
-    @retry_on_bsl
     def connect_bucket(bucket):
         if bucket not in JBoxGS.BUCKETS:
             JBoxGS.BUCKETS[bucket] = JBoxGS.connect().buckets().get(bucket=bucket).execute()
@@ -43,7 +42,6 @@ class JBoxGS(JBPluginCloud):
         return mime_type[0]
 
     @staticmethod
-    @retry_on_bsl
     def push(bucket, local_file, metadata=None):
         objconn = JBoxGS.connect().objects()
         fh = open(local_file, "rb")
@@ -61,7 +59,6 @@ class JBoxGS(JBPluginCloud):
         return KeyStruct(**k)
 
     @staticmethod
-    @retry_on_bsl
     def pull(bucket, local_file, metadata_only=False):
         objname = os.path.basename(local_file)
         k = None
@@ -94,7 +91,6 @@ class JBoxGS(JBPluginCloud):
         return KeyStruct(**k)
 
     @staticmethod
-    @retry_on_bsl
     def delete(bucket, local_file):
         key_name = os.path.basename(local_file)
         k = JBoxGS.connect().objects().delete(bucket=bucket, object=key_name).execute()
@@ -103,7 +99,6 @@ class JBoxGS(JBPluginCloud):
         return KeyStruct(**k)
 
     @staticmethod
-    @retry_on_bsl
     def copy(from_file, to_file, from_bucket, to_bucket=None):
         if to_bucket is None:
             to_bucket = from_bucket

--- a/engine/src/juliabox/plugins/compute_gce/impl_gce.py
+++ b/engine/src/juliabox/plugins/compute_gce/impl_gce.py
@@ -15,7 +15,7 @@ from oauth2client.client import GoogleCredentials
 
 from juliabox.cloud import JBPluginCloud
 from juliabox.db import JBPluginDB
-from juliabox.jbox_util import JBoxCfg, parse_iso_time, retry, retry_on_bsl
+from juliabox.jbox_util import JBoxCfg, parse_iso_time, retry, retry_on_errors
 
 class CompGCE(JBPluginCloud):
     provides = [JBPluginCloud.JBP_COMPUTE, JBPluginCloud.JBP_COMPUTE_GCE]
@@ -153,7 +153,7 @@ class CompGCE(JBPluginCloud):
             raise Exception("Invalid value_type argument.")
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def _write_metric(metric_name, labels, value, value_type):
         value_type = CompGCE._process_value_type(value_type)
         timedesc = {
@@ -308,7 +308,7 @@ class CompGCE(JBPluginCloud):
         return None
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def terminate_instance(instance=None):
         if instance is None:
             instance = CompGCE.get_instance_id()
@@ -462,7 +462,7 @@ class CompGCE(JBPluginCloud):
         return CompGCE.ZONE
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def _get_instance_data(instname):
         conn = CompGCE._connect_gce().instances()
         inst = conn.get(project=CompGCE.INSTALL_ID, zone=CompGCE._zone(),
@@ -470,7 +470,7 @@ class CompGCE(JBPluginCloud):
         return inst
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def _get_disk_data(diskname):
         conn = CompGCE._connect_gce().disks()
         disk = conn.get(project=CompGCE.INSTALL_ID, zone=CompGCE._zone(),
@@ -523,7 +523,7 @@ class CompGCE(JBPluginCloud):
         return CompGCE.MONITORING_CONN
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def _instance_attrs(instance_name=None):
         if instance_name is None:
             instance_name = CompGCE.get_instance_id()
@@ -541,7 +541,7 @@ class CompGCE(JBPluginCloud):
         return minutes
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def _get_instances(gname, only_running=False):
         conn = CompGCE._connect_gce().instanceGroups()
         flag = 'RUNNING' if only_running else 'ALL'
@@ -565,7 +565,7 @@ class CompGCE(JBPluginCloud):
         return instances
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def _increment_num_instances():
         conn = CompGCE._connect_gce().instanceGroupManagers()
         curr = conn.get(project=CompGCE.INSTALL_ID, zone=CompGCE._zone(),

--- a/engine/src/juliabox/plugins/dns_gcd/impl_gcd.py
+++ b/engine/src/juliabox/plugins/dns_gcd/impl_gcd.py
@@ -2,7 +2,7 @@ __author__ = 'Nishanth'
 
 
 from juliabox.cloud import JBPluginCloud
-from juliabox.jbox_util import JBoxCfg, retry_on_bsl
+from juliabox.jbox_util import JBoxCfg, retry_on_errors
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials
 
@@ -36,7 +36,7 @@ class JBoxGCD(JBPluginCloud):
         return JBoxGCD.CONN
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def add_cname(name, value):
         JBoxGCD.connect().changes().create(
             project=JBoxGCD.INSTALLID, managedZone=JBoxGCD.REGION,
@@ -49,7 +49,7 @@ class JBoxGCD(JBPluginCloud):
                        'ttl': 300}    ] }).execute()
 
     @staticmethod
-    @retry_on_bsl
+    @retry_on_errors(retries=2)
     def delete_cname(name):
         resp = JBoxGCD.connect().resourceRecordSets().list(
             project=JBoxGCD.INSTALLID, managedZone=JBoxGCD.REGION,

--- a/scripts/install/gce/configure_metrics.py
+++ b/scripts/install/gce/configure_metrics.py
@@ -1,9 +1,13 @@
 #!/usr/bin/python
 
-import httplib
 from sys import argv
 from googleapiclient.discovery import build
 from oauth2client.client import GoogleCredentials
+
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                             "engine", "src"))
+from juliabox.jbox_util import retry_on_errors
 
 if len(argv) != 2:
     print("Usage: ./configure_metrics <install-id>")
@@ -13,14 +17,6 @@ INSTALL_ID = argv[1]
 CUSTOM_METRIC_DOMAIN = "custom.cloudmonitoring.googleapis.com/"
 ALLOWED_CUSTOM_GCE_VALUE_TYPES = ["double", "int64"]
 ALLOWED_EC2_VALUE_TYPES = ["Percent", "Count"]
-
-def retry_on_bsl(f):
-    def func(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        except httplib.BadStatusLine as bsl:
-            return f(*args, **kwargs)
-    return func
 
 def _process_value_type(value_type):
     if value_type in ALLOWED_EC2_VALUE_TYPES:
@@ -36,7 +32,7 @@ def _connect_google_monitoring():
     return build("cloudmonitoring", "v2beta2",
                  credentials=GoogleCredentials.get_application_default())
 
-@retry_on_bsl
+@retry_on_errors()
 def _create_metric_descriptor(metric_name, value_type, label_descriptors,
                               metric_desc=""):
     value_type = _process_value_type(value_type)


### PR DESCRIPTION
Replaced the `@retry_on_bsl` decorator with `@retry_on_errors`, which considers more errors and uses exponential back-off.

This helps prevent 404 and 5xx errors that happen occasionally.

As in #384 the `max_sleep_time` of 32 seconds may be too large.