### PR TITLE
Fix truncation of `value` field of dynconfig table when using Cloudsql

### DIFF
--- a/engine/src/juliabox/db/api_spec.py
+++ b/engine/src/juliabox/db/api_spec.py
@@ -31,7 +31,7 @@ class JBoxAPISpec(JBoxDB):
         {'name': 'publisher-api_name-index', 'cols': ['publisher', 'api_name']}
     ]
     KEYS_TYPES = [JBoxDB.VCHAR]
-    TYPES = [JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR,
+    TYPES = [JBoxDB.VCHAR, JBoxDB.TEXT, JBoxDB.VCHAR, JBoxDB.VCHAR,
              JBoxDB.INT, JBoxDB.INT]
 
     def __init__(self, api_name, cmd=None, image_name=None, description=None,

--- a/engine/src/juliabox/db/db_base.py
+++ b/engine/src/juliabox/db/db_base.py
@@ -12,6 +12,7 @@ class JBoxDB(LoggerMixin):
     DB_IMPL = None
     INT = 'INT'
     VCHAR = 'VARCHAR(200)'
+    TEXT = 'TEXT'
 
     @staticmethod
     def configure():

--- a/engine/src/juliabox/db/dynconfig.py
+++ b/engine/src/juliabox/db/dynconfig.py
@@ -25,7 +25,7 @@ class JBoxDynConfig(JBoxDB):
     ATTRIBUTES = ['value']
     SQL_INDEXES = None
     KEYS_TYPES = [JBoxDB.VCHAR]
-    TYPES = [JBoxDB.VCHAR]
+    TYPES = [JBoxDB.TEXT]
 
     DEFAULT_REGISTRATION_RATE = 60
 


### PR DESCRIPTION
The size of the `value` field in `jbox_dynconfig` table was limited to 200 characters by `VARCHAR(200)`.   This was causing truncation and hence JSON parse error.  Changed it to `TEXT` which can be 65536 characters long.

Did the same for `cmd` field of `jbox_apispec`.