### PR TITLE
Upload multiple metrics in a single API call in google monitoring

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -190,6 +190,7 @@ Interfaces with cloud service providers or provides similar services locally.
     - `get_instance_public_ip(instance_id=None)`
     - `get_instance_local_ip(instance_id=None)`
     - `publish_stats(stat_name, stat_unit, stat_value)`: Record performance/load statistics.
+    - `publish_stats_multi(stats)`: Record multiple performance/load statistics.
     - `get_instance_stats(instance, stat_name, namespace=None)`: Query recorded statistics.
     - `get_cluster_stats(stat_name, namespace=None)`: Query cluster wide recorded statistics.
     - `get_cluster_average_stats(stat_name, namespace=None, results=None)`: Query cluster wide averages of recorded statistics.

--- a/engine/src/juliabox/cloud/compute.py
+++ b/engine/src/juliabox/cloud/compute.py
@@ -40,6 +40,7 @@ class JBPluginCloud(LoggerMixin):
         - `get_instance_public_ip(instance_id=None)`
         - `get_instance_local_ip(instance_id=None)`
         - `publish_stats(stat_name, stat_unit, stat_value)`: Record performance/load statistics.
+        - `publish_stats_multi(stats)`: Record multiple performance/load statistics.
         - `get_instance_stats(instance, stat_name, namespace=None)`: Query recorded statistics.
         - `get_cluster_stats(stat_name, namespace=None)`: Query cluster wide recorded statistics.
         - `get_cluster_average_stats(stat_name, namespace=None, results=None)`: Query cluster wide averages of recorded statistics.
@@ -130,6 +131,10 @@ class Compute(LoggerMixin):
     @staticmethod
     def publish_stats(stat_name, stat_unit, stat_value):
         return Compute.impl.publish_stats(stat_name, stat_unit, stat_value)
+
+    @staticmethod
+    def publish_stats_multi(stats):
+        return Compute.impl.publish_stats_multi(stats)
 
     @staticmethod
     def get_instance_stats(instance, stat_name, namespace=None):

--- a/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
+++ b/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
@@ -126,6 +126,11 @@ class CompEC2(JBPluginCloud):
                                                       unit=stat_unit, value=stat_value, dimensions=dims)
 
     @staticmethod
+    def publish_stats_multi(stats):
+        for (stat_name, stat_unit, stat_value) in stats:
+            CompEC2.publish_stats(stat_name, stat_unit, stat_value)
+
+    @staticmethod
     def get_instance_stats(instance, stat_name, namespace=None):
         if (instance == CompEC2.get_instance_id()) and (stat_name in CompEC2.SELF_STATS):
             CompEC2.log_debug("Using cached self_stats. %s=%r", stat_name, CompEC2.SELF_STATS[stat_name])

--- a/engine/src/juliabox/plugins/compute_singlenode/impl_singlenode.py
+++ b/engine/src/juliabox/plugins/compute_singlenode/impl_singlenode.py
@@ -81,6 +81,11 @@ class CompSingleNode(JBPluginCloud):
                                 stat_name, stat_value, stat_unit)
 
     @staticmethod
+    def publish_stats_multi(stats):
+        for (stat_name, stat_unit, stat_value) in stats:
+            CompSingleNode.publish_stats(stat_name, stat_unit, stat_value)
+
+    @staticmethod
     def get_instance_stats(instance, stat_name, namespace=None):
         stat_val = None
         if (instance == CompSingleNode.get_instance_id()) and (stat_name in CompSingleNode.SELF_STATS):


### PR DESCRIPTION
Implemented a method `publish_stats_multi` in google compute plugin.  This takes a list of metrics to be uploaded in a single API call.  Made changes appropriately in other compute plugins and in `publish_perf_counters` method of `JBoxd`.

This will prevent the monitoring API from being called too many times in a small interval of time.