### PR TITLE
Reconnect to MySQL on OperationalError

### DIFF
--- a/engine/src/juliabox/jbox_util.py
+++ b/engine/src/juliabox/jbox_util.py
@@ -10,7 +10,7 @@ import logging
 import isodate
 import httplib
 import errno
-
+from random import random
 
 def parse_iso_time(tm):
     if tm is not None:


### PR DESCRIPTION
It was observed that `OperationalError: (2006, 'MySQL server has gone away')` was thrown when connections went stale due to idle timeout when calling the execute method on a cursor.

Added a wrapper for execute in `JBoxCloudSQL` that catches this error and retries with a new connection.