### PR TITLE
fix sum with None exception

### DIFF
--- a/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
+++ b/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
@@ -285,7 +285,8 @@ class CompEC2(JBPluginCloud):
             cluster_load[self_instance_id] = self_load
 
         # remove machines with older AMIs
-        cluster_load = {k: v for k, v in cluster_load.iteritems() if CompEC2.get_image_recentness(k) >= 0}
+        cluster_load = {k: v for k, v in cluster_load.iteritems()
+                        if CompEC2.get_image_recentness(k) >= 0 and v is not None}
         CompEC2.log_debug("Cluster load (excluding old amis): %r", cluster_load)
 
         avg_load = CompEC2.get_cluster_average_stats('Load', results=cluster_load)


### PR DESCRIPTION
Occurs when load value of one of the instances in the cluster is fetched as `None`. Most likely for `self` instance, when request lands on an instance before it got a change to initialize it's own load value.
 
Ref exception stack
````
  File "/jboxengine/src/juliabox/plugins/auth_google/google_auth.py", line 99, in get
    self.post_auth_launch_container(user_id)
  File "/jboxengine/src/juliabox/handlers/handler_base.py", line 434, in post_auth_launch_container
    if self.try_launch_container(user_id, max_hop=False):
  File "/jboxengine/src/juliabox/handlers/handler_base.py", line 342, in try_launch_container
    if ((cont is None) or (not cont.is_running())) and (not Compute.should_accept_session(is_leader)):
  File "/jboxengine/src/juliabox/cloud/compute.py", line 165, in should_accept_session
    return Compute.impl.should_accept_session(is_leader)
  File "/jboxengine/src/juliabox/plugins/compute_ec2/impl_ec2.py", line 291, in should_accept_session
    avg_load = CompEC2.get_cluster_average_stats('Load', results=cluster_load)
  File "/jboxengine/src/juliabox/plugins/compute_ec2/impl_ec2.py", line 199, in get_cluster_average_stats
    return float(sum(vals)) / len(vals)
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
````