### PR TITLE
Support for migration plugins

### DIFF
--- a/engine/src/juliabox/cloud/compute.py
+++ b/engine/src/juliabox/cloud/compute.py
@@ -68,6 +68,8 @@ class JBPluginCloud(LoggerMixin):
     JBP_COMPUTE_SINGLENODE = "cloud.compute.singlenode"
     JBP_COMPUTE_GCE = "cloud.compute.gce"
 
+    JBP_MIGRATE = "cloud.migrate"
+
     __metaclass__ = JBoxPluginType
 
 

--- a/engine/src/juliabox/plugins/db_cloudsql/impl_cloudsql.py
+++ b/engine/src/juliabox/plugins/db_cloudsql/impl_cloudsql.py
@@ -53,7 +53,6 @@ class JBoxMySQLTable(LoggerMixin):
                 record[col] = None
         c = JBoxCloudSQL.execute(self.insert_statement, record)
         c.close()
-        self.commit()
 
     @staticmethod
     def _op(name, opstr, value, names, values):
@@ -142,7 +141,6 @@ class JBoxMySQLTable(LoggerMixin):
         # self.log_debug("SQL: %s", stmt)
         c = JBoxCloudSQL.execute(stmt, dict(zip(colnames, values)))
         c.close()
-        self.commit()
 
     def update(self, record):
         keynames = []
@@ -176,11 +174,6 @@ class JBoxMySQLTable(LoggerMixin):
         # self.log_debug("SQL: %s", stmt)
         c = JBoxCloudSQL.execute(stmt, dict(zip(names, values)))
         c.close()
-        self.commit()
-
-    @staticmethod
-    def commit():
-        JBoxCloudSQL.conn().commit()
 
 class JBoxCloudSQL(JBPluginDB):
     provides = [JBPluginDB.JBP_DB, JBPluginDB.JBP_DB_CLOUDSQL]
@@ -209,6 +202,7 @@ class JBoxCloudSQL(JBPluginDB):
             JBoxCloudSQL.threadlocal.cloudsql_conn = c = MySQLdb.connect(
                 user=JBoxCloudSQL.USER, passwd=JBoxCloudSQL.PASSWD,
                 unix_socket=JBoxCloudSQL.UNIX_SOCKET, db=JBoxCloudSQL.DB)
+            c.autocommit(True)
         return c
 
     @staticmethod

--- a/engine/src/juliabox/vol/jbox_volume.py
+++ b/engine/src/juliabox/vol/jbox_volume.py
@@ -380,11 +380,17 @@ class JBoxVol(LoggerMixin):
         sessname = unique_sessname(self.user_email)
         old_sessname = esc_sessname(self.user_email)
         src = os.path.join(JBoxVol.BACKUP_LOC, sessname + ".tar.gz")
-        k = JBoxVol.pull_from_bucketstore(src)  # download from S3 if exists
+
+        pull_from_bucketstore = JBoxVol.pull_from_bucketstore
+        mig_hndl = JBPluginCloud.jbox_get_plugin(JBPluginCloud.JBP_MIGRATE)
+        if mig_hndl and mig_hndl.should_migrate(self.user_email):
+            pull_from_bucketstore = mig_hndl.pull_from_bucketstore
+
+        k = pull_from_bucketstore(src)  # download from S3 if exists
         if not os.path.exists(src):
             if old_sessname is not None:
                 src = os.path.join(JBoxVol.BACKUP_LOC, old_sessname + ".tar.gz")
-                k = JBoxVol.pull_from_bucketstore(src)  # download from S3 if exists
+                k = pull_from_bucketstore(src)  # download from S3 if exists
 
         if not os.path.exists(src):
             return

--- a/scripts/install/create_tables_cloudsql.py
+++ b/scripts/install/create_tables_cloudsql.py
@@ -22,14 +22,14 @@ def table_exists(table_name):
     except:
         return False
 
-
-def table_create(table_name, columns, types, keys=None, keys_types=None):
+def table_create(table_name, columns=None, types=None, keys=None, keys_types=None):
     stmt = []
     if keys is not None:
         for k, t in zip(keys, keys_types):
             stmt.append(k + ' ' + t)
-    for col, t in zip(columns, types):
-        stmt.append(col + ' ' + t)
+    if columns is not None:
+        for col, t in zip(columns, types):
+            stmt.append(col + ' ' + t)
     sql = 'create table %s (%s' % (table_name, ', '.join(stmt))
     if keys is not None:
         sql += (', primary key (%s)' % (', '.join(keys),))


### PR DESCRIPTION
Migration plugins should provide two methods:
- `pull_from_bucketstore(backup_location):` Downloads user backup from the desired bucket and platform.
- `should_migrate(user_id):` Return `True` if user has been marked for migration, else `False`.

If a migration plugin is enabled and the user has been marked for migration, then the `pull_from_bucketstore` method of the plugin is used to download the user backup on login. Else, the default bucket plugin is used via `JBoxVol.pull_from_bucketstore`.

