### PR TITLE
initialize package bundle if not done

### DIFF
--- a/engine/src/juliabox/plugins/vol_defpkg/defpkg.py
+++ b/engine/src/juliabox/plugins/vol_defpkg/defpkg.py
@@ -58,6 +58,10 @@ class JBoxDefaultPackagesVol(JBoxVol):
     @staticmethod
     def get_disk_for_user(user_email):
         JBoxDefaultPackagesVol.log_debug("creating default packages mounted disk for %s", user_email)
+        if JBoxDefaultPackagesVol.FS_LOC is None:
+            JBoxDefaultPackagesVol.configure()
+        if JBoxDefaultPackagesVol.CURRENT_BUNDLE is None:
+            JBoxDefaultPackagesVol.refresh_user_home_image()
         disk_path = os.path.join(JBoxDefaultPackagesVol.FS_LOC, JBoxDefaultPackagesVol.CURRENT_BUNDLE)
         pkgvol = JBoxDefaultPackagesVol(disk_path, user_email=user_email)
         return pkgvol


### PR DESCRIPTION
Package bundles do not get initialized occasionally, likely due to a race condition in the triggering message sent from `jbox` to `jboxd`. This is not a problem when the installation has them configured and updated separately. But logins fail on a single node or static cluster when this occurs. This fix is to check and initialize package bundles before using.

fixes #392
