### PR TITLE
fix a few session startup issues

### DIFF
--- a/engine/src/juliabox/db/__init__.py
+++ b/engine/src/juliabox/db/__init__.py
@@ -40,7 +40,10 @@ def is_cluster_leader():
     # if none set, or set instance is dead elect self as leader, but wait till next cycle to prevent conflicts
     if (leader is None) or (leader not in instances) and (img_recentness >= 0):
         JBoxDB.log_info("setting self (%s) as cluster leader", self_id)
-        JBoxDynConfig.set_cluster_leader(cluster, self_id)
+        try:
+            JBoxDynConfig.set_cluster_leader(cluster, self_id)
+        except:
+            JBoxDB.log_info("error setting self (%s) as cluster leader, will retry", self_id)
         return False
 
     is_leader = (leader == self_id)

--- a/engine/src/juliabox/handlers/main.py
+++ b/engine/src/juliabox/handlers/main.py
@@ -45,7 +45,7 @@ class MainHandler(JBoxHandler):
         cont = SessContainer.get_by_name(sessname)
         if (cont is None) or (not cont.is_running()):
             loading_step = int(self.get_loading_state(), 0)
-            if loading_step > 30:
+            if loading_step > 60:
                 self.log_error("Could not start instance. Session [%s] for user [%s] didn't load.", sessname, user_id)
                 self.write({'code': -1})
                 return

--- a/engine/src/juliabox/interactive/sess_container.py
+++ b/engine/src/juliabox/interactive/sess_container.py
@@ -170,6 +170,11 @@ class SessContainer(BaseContainer):
                 SessContainer.log_warn("Inactive beyond allowed time %s. Scheduling cleanup.", cont.debug_str())
                 SessContainer.invalidate_container(cont.get_name())
                 JBoxAsyncJob.async_backup_and_cleanup(cont.dockid)
+            elif not c_is_active and ((tnow-cont.time_finished()).total_seconds() > (10*60)):
+                SessContainer.log_warn("Dead container %s. Deleting.", cont.debug_str())
+                cont.delete(backup=False)
+                del all_cnames[cname]
+                container_id_list.remove(cid)
 
         # delete ping entries for non exixtent containers
         for cname in SessContainer.PINGS.keys():

--- a/webserver/scripts/router.lua
+++ b/webserver/scripts/router.lua
@@ -225,7 +225,7 @@ function M.check_forward_addr(outgoing, replacement)
 end
 
 function M.delay_till_available(outgoing, path)
-    M.wait_till_accessible(outgoing .. path, 20)
+    M.wait_till_accessible(outgoing .. path, 60)
     return
 end
 


### PR DESCRIPTION
- Restart container if it fails to start properly. Occasionally the docker container fails to respond to the exposed ports. Now we attempt to resuscitate the container if it fails to start properly.
- Starting the first session on a fresh instance sometimes times out, because of warming up overhead. Increase startup timeout.
- When both API and interactive sessions are co-located, both may try to elect the instance as cluster leader at the same time. That would result in a concurrent update error. Not fatal, but good to have it handled.
