### PR TITLE
scale to large number of instances

### DIFF
--- a/engine/src/juliabox/api/api_container.py
+++ b/engine/src/juliabox/api/api_container.py
@@ -269,20 +269,20 @@ class APIContainer(BaseContainer):
         APIContainer.API_CONTAINERS[api_name] = clist
         APIContainer.log_info("Deregistered " + cname)
 
-    @staticmethod
-    def get_cluster_api_status():
-        result = dict()
-        for inst in Compute.get_all_instances():
-            try:
-                api_status = JBoxAsyncJob.sync_api_status(inst)
-                if api_status['code'] == 0:
-                    result[inst] = api_status['data']
-                else:
-                    APIContainer.log_error("error fetching api status from %s", inst)
-            except:
-                APIContainer.log_error("exception fetching api status from %s", inst)
-        APIContainer.log_debug("api status: %r", result)
-        return result
+    # @staticmethod
+    # def get_cluster_api_status():
+    #     result = dict()
+    #     for inst in Compute.get_all_instances():
+    #         try:
+    #             api_status = JBoxAsyncJob.sync_api_status(inst)
+    #             if api_status['code'] == 0:
+    #                 result[inst] = api_status['data']
+    #             else:
+    #                 APIContainer.log_error("error fetching api status from %s", inst)
+    #         except:
+    #             APIContainer.log_error("exception fetching api status from %s", inst)
+    #     APIContainer.log_debug("api status: %r", result)
+    #     return result
 
     def on_start(self):
         APIContainer.register_api_container(self.get_api_name(), self.get_name())

--- a/engine/src/juliabox/db/__init__.py
+++ b/engine/src/juliabox/db/__init__.py
@@ -2,6 +2,7 @@ __author__ = 'tan'
 from db_base import JBoxDB, JBPluginDB, JBoxDBItemNotFound
 from user_v2 import JBoxUserV2
 from container import JBoxSessionProps
+from instance import JBoxInstanceProps
 from dynconfig import JBoxDynConfig
 from api_spec import JBoxAPISpec
 from juliabox.cloud import Compute

--- a/engine/src/juliabox/db/container.py
+++ b/engine/src/juliabox/db/container.py
@@ -1,4 +1,6 @@
 import json
+import datetime
+import pytz
 
 from boto.dynamodb2.fields import HashKey
 from boto.dynamodb2.types import STRING
@@ -18,13 +20,19 @@ class JBoxSessionProps(JBoxDB):
     TABLE = None
 
     KEYS = ['session_id']
-    ATTRIBUTES = ['user_id', 'snapshot_id', 'message']
+    ATTRIBUTES = ['user_id', 'snapshot_id', 'message', 'instance_id', 'attach_time', 'container_state']
     SQL_INDEXES = None
     KEYS_TYPES = [JBoxDB.VCHAR]
-    TYPES = [JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR]
+    TYPES = [JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.INT, JBoxDB.VCHAR]
+
+    # maintenance runs are once in 5 minutes
+    # TODO: make configurable
+    SESS_UPDATE_INTERVAL = (5 * 1.5) * 60
 
     def __init__(self, session_id, create=False, user_id=None):
         try:
+            if session_id.startswith("/"):
+                session_id = session_id[1:]
             self.item = self.fetch(session_id=session_id)
             self.is_new = False
         except JBoxDBItemNotFound:
@@ -52,6 +60,43 @@ class JBoxSessionProps(JBoxDB):
     def set_snapshot_id(self, snapshot_id):
         self.set_attrib('snapshot_id', snapshot_id)
 
+    def get_instance_id(self):
+        now = datetime.datetime.now(pytz.utc)
+        attach_time = JBoxSessionProps.epoch_secs_to_datetime(int(self.get_attrib('attach_time', 0)))
+        if (now - attach_time).total_seconds() > JBoxSessionProps.SESS_UPDATE_INTERVAL:
+            return None
+        return self.get_attrib('instance_id')
+
+    def set_instance_id(self, instance_id):
+        self.set_attrib('instance_id', instance_id)
+        attach_time = datetime.datetime.now(pytz.utc)
+        self.set_attrib('attach_time', JBoxSessionProps.datetime_to_epoch_secs(attach_time))
+
+    def unset_instance_id(self, instance_id):
+        if self.get_instance_id() == instance_id:
+            self.set_instance_id("")
+
+    def set_container_state(self, container_state):
+        self.set_attrib('container_state', container_state)
+
+    def get_container_state(self):
+        self.get_attrib('container_state', '')
+
+    @staticmethod
+    def attach_instance(session_id, instance_id, container_state=None):
+        sessprops = JBoxSessionProps(session_id, create=True)
+        sessprops.set_instance_id(instance_id)
+        if container_state:
+            sessprops.set_container_state(container_state)
+        sessprops.save()
+
+    @staticmethod
+    def detach_instance(session_id, instance_id):
+        sessprops = JBoxSessionProps(session_id, create=True)
+        sessprops.unset_instance_id(instance_id)
+        sessprops.set_container_state('')
+        sessprops.save()
+
     def get_message(self):
         msg = self.get_attrib('message')
         if msg is not None:
@@ -64,3 +109,17 @@ class JBoxSessionProps(JBoxDB):
             'del': delete_on_display
         }
         self.set_attrib('message', json.dumps(msg))
+
+    @staticmethod
+    def get_active_sessions():
+        now = datetime.datetime.now(pytz.utc)
+        nowsecs = JBoxSessionProps.datetime_to_epoch_secs(now)
+        valid_time = nowsecs - JBoxSessionProps.SESS_UPDATE_INTERVAL
+        result = dict()
+        for record in JBoxSessionProps.scan(attach_time__gte=valid_time, instance_id__gt=" "):
+            instance_id = record.get('instance_id', None)
+            if instance_id:
+                sessions = result.get(instance_id, dict())
+                sessions[record.get('session_id')] = record.get('container_state', 'Unknown')
+                result[instance_id] = sessions
+        return result

--- a/engine/src/juliabox/db/db_base.py
+++ b/engine/src/juliabox/db/db_base.py
@@ -88,6 +88,10 @@ class JBoxDB(LoggerMixin):
         epoch = datetime.datetime.fromtimestamp(0, pytz.utc)
         return epoch + datetime.timedelta(seconds=secs)
 
+    @staticmethod
+    def qual(cluster, name):
+        return '.'.join([cluster, name])
+
 
 class JBPluginDB(JBoxDB):
     """ Provide database access and database table definitions.

--- a/engine/src/juliabox/db/dynconfig.py
+++ b/engine/src/juliabox/db/dynconfig.py
@@ -46,10 +46,6 @@ class JBoxDynConfig(JBoxDB):
             else:
                 raise
 
-    @staticmethod
-    def _n(cluster, name):
-        return '.'.join([cluster, name])
-
     def set_value(self, value):
         self.set_attrib('value', value)
 
@@ -59,14 +55,14 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def unset_cluster_leader(cluster):
         try:
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'leader'))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, 'leader'))
             record.delete()
         except JBoxDBItemNotFound:
             return
 
     @staticmethod
     def set_cluster_leader(cluster, instance):
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'leader'), create=True, value=instance)
+        record = JBoxDynConfig(JBoxDB.qual(cluster, 'leader'), create=True, value=instance)
         if not record.is_new:
             record.set_value(instance)
             record.save()
@@ -74,13 +70,13 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_cluster_leader(cluster):
         try:
-            return JBoxDynConfig(JBoxDynConfig._n(cluster, 'leader')).get_value()
+            return JBoxDynConfig(JBoxDB.qual(cluster, 'leader')).get_value()
         except JBoxDBItemNotFound:
             return None
 
     @staticmethod
     def set_allow_registration(cluster, allow):
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'allow_registration'), create=True, value=str(allow))
+        record = JBoxDynConfig(JBoxDB.qual(cluster, 'allow_registration'), create=True, value=str(allow))
         if not record.is_new:
             record.set_value(str(allow))
             record.save()
@@ -88,7 +84,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_allow_registration(cluster):
         try:
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'allow_registration'))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, 'allow_registration'))
         except JBoxDBItemNotFound:
             return True
 
@@ -97,13 +93,13 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_registration_hourly_rate(cluster):
         try:
-            return int(JBoxDynConfig(JBoxDynConfig._n(cluster, 'registrations_hourly_rate')).get_value())
+            return int(JBoxDynConfig(JBoxDB.qual(cluster, 'registrations_hourly_rate')).get_value())
         except JBoxDBItemNotFound:
             return JBoxDynConfig.DEFAULT_REGISTRATION_RATE
 
     @staticmethod
     def set_registration_hourly_rate(cluster, rate):
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'registrations_hourly_rate'), create=True, value=str(rate))
+        record = JBoxDynConfig(JBoxDB.qual(cluster, 'registrations_hourly_rate'), create=True, value=str(rate))
         if not record.is_new:
             record.set_value(str(rate))
             record.save()
@@ -118,7 +114,7 @@ class JBoxDynConfig(JBoxDB):
             'valid_till': isodate.datetime_isoformat(tvalid)
         }
         msg = json.dumps(msg)
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'message'), create=True, value=msg)
+        record = JBoxDynConfig(JBoxDB.qual(cluster, 'message'), create=True, value=msg)
         if not record.is_new:
             record.set_value(msg)
             record.save()
@@ -126,7 +122,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_message(cluster, del_expired=True):
         try:
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'message'))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, 'message'))
         except JBoxDBItemNotFound:
             return None
 
@@ -150,7 +146,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_user_home_image(cluster):
         try:
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_home_image'))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, 'user_home_image'))
         except JBoxDBItemNotFound:
             return None, None, None
         img = json.loads(record.get_value())
@@ -166,7 +162,7 @@ class JBoxDynConfig(JBoxDB):
             'home_file': home_file
         }
         img = json.dumps(img)
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_home_image'), create=True, value=img)
+        record = JBoxDynConfig(JBoxDB.qual(cluster, 'user_home_image'), create=True, value=img)
         if not record.is_new:
             record.set_value(img)
             record.save()
@@ -174,7 +170,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def set_stat_collected_date(cluster):
         dt = datetime.datetime.now(pytz.utc).isoformat()
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'stat_date'), create=True, value=dt)
+        record = JBoxDynConfig(JBoxDB.qual(cluster, 'stat_date'), create=True, value=dt)
         if not record.is_new:
             record.set_value(dt)
             record.save()
@@ -182,7 +178,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_stat_collected_date(cluster):
         try:
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'stat_date'))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, 'stat_date'))
         except JBoxDBItemNotFound:
             return None
         return parse_iso_time(record.get_value())
@@ -198,7 +194,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def set_stat(cluster, stat_name, stat):
         val = json.dumps(stat)
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, stat_name), create=True, value=val)
+        record = JBoxDynConfig(JBoxDB.qual(cluster, stat_name), create=True, value=val)
         if not record.is_new:
             record.set_value(val)
             record.save()
@@ -206,7 +202,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_stat(cluster, stat_name):
         try:
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, stat_name))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, stat_name))
         except JBoxDBItemNotFound:
             return None
         return json.loads(record.get_value())
@@ -215,7 +211,7 @@ class JBoxDynConfig(JBoxDB):
     def get_course(cluster, course_id):
         try:
             course_key = '|'.join(['course', course_id])
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, course_key))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, course_key))
         except JBoxDBItemNotFound:
             return None
         return json.loads(record.get_value())
@@ -224,7 +220,7 @@ class JBoxDynConfig(JBoxDB):
     def set_course(cluster, course_id, course_details):
         val = json.dumps(course_details)
         course_key = '|'.join(['course', course_id])
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, course_key), create=True, value=val)
+        record = JBoxDynConfig(JBoxDB.qual(cluster, course_key), create=True, value=val)
         if not record.is_new:
             record.set_value(val)
             record.save()
@@ -232,7 +228,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def get_user_cluster_config(cluster):
         try:
-            record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_cluster'))
+            record = JBoxDynConfig(JBoxDB.qual(cluster, 'user_cluster'))
         except JBoxDBItemNotFound:
             return None
         return json.loads(record.get_value())
@@ -240,7 +236,7 @@ class JBoxDynConfig(JBoxDB):
     @staticmethod
     def set_user_cluster_config(cluster, cfg):
         val = json.dumps(cfg)
-        record = JBoxDynConfig(JBoxDynConfig._n(cluster, 'user_cluster'), create=True, value=val)
+        record = JBoxDynConfig(JBoxDB.qual(cluster, 'user_cluster'), create=True, value=val)
         if not record.is_new:
             record.set_value(val)
             record.save()

--- a/engine/src/juliabox/db/instance.py
+++ b/engine/src/juliabox/db/instance.py
@@ -1,0 +1,128 @@
+import json
+import datetime
+import pytz
+
+from boto.dynamodb2.fields import HashKey
+from boto.dynamodb2.types import STRING
+
+from juliabox.db import JBoxDB, JBoxDBItemNotFound
+
+
+class JBoxInstanceProps(JBoxDB):
+    NAME = 'jbox_instance'
+
+    SCHEMA = [
+        HashKey('instance_id', data_type=STRING)
+    ]
+
+    INDEXES = None
+
+    TABLE = None
+
+    KEYS = ['instance_id']
+    ATTRIBUTES = ['load', 'accept', 'api_status', 'publish_time']
+    SQL_INDEXES = None
+    KEYS_TYPES = [JBoxDB.VCHAR]
+    TYPES = [JBoxDB.VCHAR, JBoxDB.INT, JBoxDB.TEXT, JBoxDB.INT]
+
+    # maintenance runs are once in 5 minutes
+    # TODO: make configurable
+    SESS_UPDATE_INTERVAL = (5 * 1.5) * 60
+
+    def __init__(self, instance_id, create=False):
+        try:
+            self.item = self.fetch(instance_id=instance_id)
+            self.is_new = False
+        except JBoxDBItemNotFound:
+            if create:
+                data = {
+                    'instance_id': instance_id
+                }
+                self.create(data)
+                self.item = self.fetch(instance_id=instance_id)
+                self.is_new = True
+            else:
+                raise
+
+    def get_load(self):
+        return self.get_attrib('load', '0.0')
+
+    def set_load(self, load):
+        self.set_attrib('load', str(load))
+
+    def get_accept(self):
+        return self.get_attrib('accept', 0) == 1
+
+    def set_accept(self, accept):
+        self.set_attrib('accept', 1 if accept else 0)
+
+    def get_api_status(self):
+        try:
+            return json.loads(self.get_attrib('api_status', '{}'))
+        except:
+            return dict()
+
+    def set_api_status(self, api_status):
+        self.set_attrib('api_status', json.dumps(api_status))
+
+    def set_publish_time(self):
+        now = datetime.datetime.now(pytz.utc)
+        self.set_attrib('publish_time', JBoxInstanceProps.datetime_to_epoch_secs(now))
+
+    def get_publish_time(self):
+        now = datetime.datetime.now(pytz.utc)
+        return int(self.get_attrib('publish_time', JBoxInstanceProps.datetime_to_epoch_secs(now)))
+
+    @staticmethod
+    def set_props(instance_id, load=None, accept=None, api_status=None):
+        instance_props = JBoxInstanceProps(instance_id, create=True)
+        if load is not None:
+            instance_props.set_load(load)
+        if accept is not None:
+            instance_props.set_accept(accept)
+        if api_status is not None:
+            instance_props.set_api_status(api_status)
+        instance_props.set_publish_time()
+        instance_props.save()
+
+    @staticmethod
+    def purge_stale_instances():
+        for iid in JBoxInstanceProps.get_stale_instances():
+            instance = JBoxInstanceProps(iid)
+            instance.delete()
+
+    @staticmethod
+    def get_stale_instances():
+        now = datetime.datetime.now(pytz.utc)
+        nowsecs = JBoxInstanceProps.datetime_to_epoch_secs(now)
+        valid_time = nowsecs - JBoxInstanceProps.SESS_UPDATE_INTERVAL
+        stale = []
+        for record in JBoxInstanceProps.scan(publish_time__lt=valid_time):
+            stale.append(record.get('instance_id'))
+        return stale
+
+    @staticmethod
+    def get_instance_status():
+        now = datetime.datetime.now(pytz.utc)
+        nowsecs = JBoxInstanceProps.datetime_to_epoch_secs(now)
+        valid_time = nowsecs - JBoxInstanceProps.SESS_UPDATE_INTERVAL
+        result = dict()
+        for record in JBoxInstanceProps.scan(publish_time__gte=valid_time):
+            iid = record.get('instance_id')
+            props = {
+                'load': float(record.get('load', '0.0')),
+                'accept': bool(record.get('accept', 0)),
+                'api_status': json.loads(record.get('api_status', '{}'))
+            }
+            result[iid] = props
+        return result
+
+    @staticmethod
+    def get_available_instances():
+        now = datetime.datetime.now(pytz.utc)
+        nowsecs = JBoxInstanceProps.datetime_to_epoch_secs(now)
+        valid_time = nowsecs - JBoxInstanceProps.SESS_UPDATE_INTERVAL
+        result = list()
+        for record in JBoxInstanceProps.scan(publish_time__gte=valid_time, accept__eq=1):
+            result.append(record.get('instance_id'))
+        return result

--- a/engine/src/juliabox/handlers/admin.py
+++ b/engine/src/juliabox/handlers/admin.py
@@ -8,7 +8,7 @@ from juliabox.jbox_util import JBoxCfg
 from handler_base import JBoxHandler
 from juliabox.interactive import SessContainer
 from juliabox.jbox_tasks import JBoxAsyncJob
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBPluginDB, JBoxSessionProps
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBPluginDB, JBoxSessionProps, JBoxInstanceProps
 from juliabox.api import APIContainer
 
 
@@ -121,17 +121,17 @@ class AdminHandler(JBoxHandler):
                     result = {}
                     # get cluster loads
                     average_load = Compute.get_cluster_average_stats('Load')
-                    if None != average_load:
+                    if average_load is not None:
                         result['Average Load'] = average_load
 
                     machine_loads = Compute.get_cluster_stats('Load')
-                    if None != machine_loads:
+                    if machine_loads is not None:
                         for n, v in machine_loads.iteritems():
                             result['Instance ' + n] = v
                 elif stats == 'sessions':
                     result = JBoxSessionProps.get_active_sessions()
                 elif stats == 'apis':
-                    result = APIContainer.get_cluster_api_status()
+                    result = JBoxInstanceProps.get_instance_status()
                 else:
                     raise Exception("unknown command %s" % (stats,))
 

--- a/engine/src/juliabox/handlers/admin.py
+++ b/engine/src/juliabox/handlers/admin.py
@@ -8,7 +8,7 @@ from juliabox.jbox_util import JBoxCfg
 from handler_base import JBoxHandler
 from juliabox.interactive import SessContainer
 from juliabox.jbox_tasks import JBoxAsyncJob
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBPluginDB
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBPluginDB, JBoxSessionProps
 from juliabox.api import APIContainer
 
 
@@ -129,15 +129,7 @@ class AdminHandler(JBoxHandler):
                         for n, v in machine_loads.iteritems():
                             result['Instance ' + n] = v
                 elif stats == 'sessions':
-                    result = dict()
-                    instances = Compute.get_all_instances()
-
-                    for idx in range(0, len(instances)):
-                        try:
-                            inst = instances[idx]
-                            result[inst] = JBoxAsyncJob.sync_session_status(inst)['data']
-                        except:
-                            JBoxHandler.log_error("Error receiving sessions list from %r", inst)
+                    result = JBoxSessionProps.get_active_sessions()
                 elif stats == 'apis':
                     result = APIContainer.get_cluster_api_status()
                 else:

--- a/engine/src/juliabox/handlers/admin.py
+++ b/engine/src/juliabox/handlers/admin.py
@@ -131,7 +131,7 @@ class AdminHandler(JBoxHandler):
                 elif stats == 'sessions':
                     result = JBoxSessionProps.get_active_sessions()
                 elif stats == 'apis':
-                    result = JBoxInstanceProps.get_instance_status()
+                    result = JBoxInstanceProps.get_instance_status(Compute.get_install_id())
                 else:
                     raise Exception("unknown command %s" % (stats,))
 

--- a/engine/src/juliabox/handlers/api_info.py
+++ b/engine/src/juliabox/handlers/api_info.py
@@ -1,10 +1,10 @@
-__author__ = 'tan'
-
 from handler_base import JBoxHandler
 from juliabox.jbox_util import JBoxCfg
 from juliabox.jbox_crypto import signstr
-from juliabox.api import APIContainer
+from juliabox.cloud import Compute
 from juliabox.db import JBoxInstanceProps
+
+__author__ = 'tan'
 
 
 class APIInfoHandler(JBoxHandler):
@@ -23,7 +23,7 @@ class APIInfoHandler(JBoxHandler):
             self.send_error()
             return
 
-        api_status = JBoxInstanceProps.get_instance_status()
+        api_status = JBoxInstanceProps.get_instance_status(Compute.get_install_id())
         self.log_info("cluster api status: %r", api_status)
 
         # filter out instances that should not accept more load

--- a/engine/src/juliabox/handlers/api_info.py
+++ b/engine/src/juliabox/handlers/api_info.py
@@ -4,6 +4,7 @@ from handler_base import JBoxHandler
 from juliabox.jbox_util import JBoxCfg
 from juliabox.jbox_crypto import signstr
 from juliabox.api import APIContainer
+from juliabox.db import JBoxInstanceProps
 
 
 class APIInfoHandler(JBoxHandler):
@@ -22,7 +23,7 @@ class APIInfoHandler(JBoxHandler):
             self.send_error()
             return
 
-        api_status = APIContainer.get_cluster_api_status()
+        api_status = JBoxInstanceProps.get_instance_status()
         self.log_info("cluster api status: %r", api_status)
 
         # filter out instances that should not accept more load

--- a/engine/src/juliabox/handlers/handler_base.py
+++ b/engine/src/juliabox/handlers/handler_base.py
@@ -383,7 +383,7 @@ class JBoxHandler(JBoxCookies):
     def find_logged_in_instance(user_id):
         sessname = unique_sessname(user_id)
         try:
-            sess_props = JBoxSessionProps(sessname)
+            sess_props = JBoxSessionProps(Compute.get_install_id(), sessname)
             return sess_props.get_instance_id()
         except JBoxDBItemNotFound:
             return None

--- a/engine/src/juliabox/interactive/sess_container.py
+++ b/engine/src/juliabox/interactive/sess_container.py
@@ -211,21 +211,21 @@ class SessContainer(BaseContainer):
         except:
             return False
 
-    @staticmethod
-    def get_active_sessions():
-        instances = Compute.get_all_instances()
-
-        active_sessions = set()
-        for inst in instances:
-            try:
-                sessions = JBoxAsyncJob.sync_session_status(inst)['data']
-                if len(sessions) > 0:
-                    for sess_id in sessions.keys():
-                        active_sessions.add(sess_id)
-            except:
-                SessContainer.log_error("Error receiving sessions list from %r", inst)
-
-        return active_sessions
+    # @staticmethod
+    # def get_active_sessions():
+    #     instances = Compute.get_all_instances()
+    #
+    #     active_sessions = set()
+    #     for inst in instances:
+    #         try:
+    #             sessions = JBoxAsyncJob.sync_session_status(inst)['data']
+    #             if len(sessions) > 0:
+    #                 for sess_id in sessions.keys():
+    #                     active_sessions.add(sess_id)
+    #         except:
+    #             SessContainer.log_error("Error receiving sessions list from %r", inst)
+    #
+    #     return active_sessions
 
     def backup_and_cleanup(self):
         self.stop()

--- a/engine/src/juliabox/jbox_tasks.py
+++ b/engine/src/juliabox/jbox_tasks.py
@@ -185,10 +185,10 @@ class JBoxAsyncJob(LoggerMixin):
         JBoxAsyncJob.log_info("scheduling cleanup for %s", dockid)
         JBoxAsyncJob.get().send(JBoxAsyncJob.CMD_BACKUP_CLEANUP, dockid)
 
-    @staticmethod
-    def sync_session_status(instance_id):
-        JBoxAsyncJob.log_debug("fetching session status from %r", instance_id)
-        return JBoxAsyncJob.get().sendrecv(JBoxAsyncJob.CMD_SESSION_STATUS, {}, dest=instance_id)
+    # @staticmethod
+    # def sync_session_status(instance_id):
+    #     JBoxAsyncJob.log_debug("fetching session status from %r", instance_id)
+    #     return JBoxAsyncJob.get().sendrecv(JBoxAsyncJob.CMD_SESSION_STATUS, {}, dest=instance_id)
 
     @staticmethod
     def sync_api_status(instance_id):

--- a/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
+++ b/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
@@ -1,6 +1,7 @@
 __author__ = 'tan'
 
 import datetime
+import random
 import sys
 import pytz
 import boto
@@ -11,7 +12,7 @@ import boto.ec2.autoscale
 
 from juliabox.cloud import JBPluginCloud
 from juliabox.jbox_util import JBoxCfg, parse_iso_time, retry
-
+from juliabox.db import JBoxInstanceProps
 
 class CompEC2(JBPluginCloud):
     provides = [JBPluginCloud.JBP_COMPUTE, JBPluginCloud.JBP_COMPUTE_EC2]
@@ -28,6 +29,7 @@ class CompEC2(JBPluginCloud):
     SCALE_UP_POLICY = None
     SCALE_UP_AT_LOAD = 80
     LAST_SCALE_UP_TIME = None
+    SCALE = False
 
     INSTANCE_ID = None
     INSTANCE_IMAGE_VERS = {}
@@ -44,6 +46,7 @@ class CompEC2(JBPluginCloud):
         CompEC2.SCALE_UP_AT_LOAD = JBoxCfg.get('cloud_host.scale_up_at_load', 80)
         CompEC2.SCALE_UP_POLICY = JBoxCfg.get('cloud_host.scale_up_policy', None)
         CompEC2.AUTOSCALE_GROUP = JBoxCfg.get('cloud_host.autoscale_group', None)
+        CompEC2.SCALE = JBoxCfg.get('cloud_host.scale_down')
 
         CompEC2.INSTALL_ID = JBoxCfg.get('cloud_host.install_id', 'JuliaBox')
         CompEC2.REGION = JBoxCfg.get('cloud_host.region', 'us-east-1')
@@ -212,6 +215,10 @@ class CompEC2(JBPluginCloud):
 
     @staticmethod
     def can_terminate(is_leader):
+        if not CompEC2.SCALE:
+            CompEC2.log_debug("not terminating as cluster size is fixed")
+            return False
+
         uptime = CompEC2._uptime_minutes()
 
         # if uptime less than hour return false
@@ -244,6 +251,14 @@ class CompEC2(JBPluginCloud):
 
     @staticmethod
     def get_redirect_instance_id():
+        if not CompEC2.SCALE:
+            CompEC2.log_debug("cluster size is fixed")
+            available_nodes = JBoxInstanceProps.get_available_instances()
+            if len(available_nodes) > 0:
+                return random.choice(available_nodes)
+            else:
+                return None
+
         cluster_load = CompEC2.get_cluster_stats('Load')
         cluster_load = {k: v for k, v in cluster_load.iteritems() if CompEC2.get_image_recentness(k) >= 0}
         avg_load = CompEC2.get_cluster_average_stats('Load', results=cluster_load)
@@ -276,6 +291,11 @@ class CompEC2(JBPluginCloud):
         self_instance_id = CompEC2.get_instance_id()
         self_load = CompEC2.get_instance_stats(self_instance_id, 'Load')
         CompEC2.log_debug("Self load: %r", self_load)
+
+        if not CompEC2.SCALE:
+            accept = self_load < 100
+            CompEC2.log_debug("cluster size is fixed. accept: %r", accept)
+            return accept
 
         cluster_load = CompEC2.get_cluster_stats('Load')
         CompEC2.log_debug("Cluster load: %r", cluster_load)
@@ -444,6 +464,10 @@ class CompEC2(JBPluginCloud):
 
     @staticmethod
     def get_image_recentness(instance=None):
+        if not CompEC2.SCALE:
+            CompEC2.log_debug("ignoring image recentness as cluster size is fixed")
+            return 0
+
         instances = CompEC2.get_all_instances()
         if instances is None:
             return 0

--- a/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
+++ b/engine/src/juliabox/plugins/compute_ec2/impl_ec2.py
@@ -1,5 +1,3 @@
-__author__ = 'tan'
-
 import datetime
 import random
 import sys
@@ -10,9 +8,12 @@ import boto.ec2
 import boto.ec2.cloudwatch
 import boto.ec2.autoscale
 
-from juliabox.cloud import JBPluginCloud
+from juliabox.cloud import JBPluginCloud, Compute
 from juliabox.jbox_util import JBoxCfg, parse_iso_time, retry
 from juliabox.db import JBoxInstanceProps
+
+__author__ = 'tan'
+
 
 class CompEC2(JBPluginCloud):
     provides = [JBPluginCloud.JBP_COMPUTE, JBPluginCloud.JBP_COMPUTE_EC2]
@@ -253,7 +254,7 @@ class CompEC2(JBPluginCloud):
     def get_redirect_instance_id():
         if not CompEC2.SCALE:
             CompEC2.log_debug("cluster size is fixed")
-            available_nodes = JBoxInstanceProps.get_available_instances()
+            available_nodes = JBoxInstanceProps.get_available_instances(Compute.get_install_id())
             if len(available_nodes) > 0:
                 return random.choice(available_nodes)
             else:

--- a/engine/src/juliabox/plugins/parallel/parallel_housekeep.py
+++ b/engine/src/juliabox/plugins/parallel/parallel_housekeep.py
@@ -1,10 +1,11 @@
-__author__ = 'tan'
 from juliabox.jbox_tasks import JBPluginTask
-from juliabox.interactive import SessContainer
 from juliabox.srvr_jboxd import jboxd_method
 from juliabox.db import JBoxSessionProps, JBoxDBItemNotFound
+from juliabox.cloud import Compute
 
 from user_cluster import UserCluster
+
+__author__ = 'tan'
 
 
 class ParallelHousekeep(JBPluginTask):
@@ -25,7 +26,7 @@ class ParallelHousekeep(JBPluginTask):
         for cluster_id in active_clusters:
             sessname = UserCluster.sessname_for_cluster(cluster_id)
             try:
-                sess_props = JBoxSessionProps(sessname)
+                sess_props = JBoxSessionProps(Compute.get_install_id(), sessname)
                 if not sess_props.get_instance_id():
                     ParallelHousekeep.log_info(
                         "Session (%s) corresponding to cluster (%s) not found. Terminating cluster.",

--- a/engine/src/juliabox/plugins/vol_ebs/ebs_housekeep.py
+++ b/engine/src/juliabox/plugins/vol_ebs/ebs_housekeep.py
@@ -1,4 +1,3 @@
-__author__ = 'tan'
 import pytz
 import os
 import datetime
@@ -9,8 +8,10 @@ from juliabox.plugins.compute_ec2 import EBSVol
 from juliabox.jbox_util import unique_sessname
 from juliabox.srvr_jboxd import jboxd_method
 from juliabox.interactive import SessContainer
+from juliabox.cloud import Compute
 from disk_state_tbl import JBoxDiskState
 from ebs import JBoxEBSVol
+__author__ = 'tan'
 
 
 class JBoxEBSHousekeep(JBPluginTask):
@@ -51,7 +52,7 @@ class JBoxEBSHousekeep(JBPluginTask):
         for disk_key in detached_disks:
             disk_info = JBoxDiskState(disk_key=disk_key)
             user_id = disk_info.get_user_id()
-            sess_props = JBoxSessionProps(unique_sessname(user_id))
+            sess_props = JBoxSessionProps(Compute.get_install_id(), unique_sessname(user_id))
             incomplete_snapshots = []
             modified = False
             for snap_id in disk_info.get_snapshot_ids():

--- a/engine/src/juliabox/srvr_jbox.py
+++ b/engine/src/juliabox/srvr_jbox.py
@@ -10,7 +10,7 @@ from tornado.httpclient import AsyncHTTPClient
 
 from cloud import Compute, JBPluginCloud
 import db
-from db import JBoxDynConfig, JBoxUserV2, is_cluster_leader, JBPluginDB
+from db import JBoxDynConfig, JBoxUserV2, JBoxInstanceProps, is_cluster_leader, JBPluginDB
 from jbox_tasks import JBoxAsyncJob
 from jbox_util import LoggerMixin, JBoxCfg
 from jbox_tasks import JBPluginTask
@@ -113,18 +113,12 @@ class JBox(LoggerMixin):
 
     @staticmethod
     def update_juliabox_status():
-        instances = Compute.get_all_instances()
+        in_error = len(JBoxInstanceProps.get_stale_instances())
+        instance_status = JBoxInstanceProps.get_instance_status()
 
-        in_error = 0
         HTML = "<html><body><center><pre>\nJuliaBox is Up.\n\nLast updated: " + datetime.datetime.now().isoformat() + " UTC\n\nLoads: "
-
-        for inst in instances:
-            try:
-                status = JBoxAsyncJob.sync_api_status(inst)['data']
-                HTML += (str(status['load']) + '% ')
-            except:
-                in_error += 1
-                pass
+        for iid in instance_status:
+            HTML += (str(instance_status[iid]['load']) + '% ')
 
         HTML += ("\n\nErrors: " + str(in_error) + "\n\nAWS Status: <a href='http://status.aws.amazon.com/'>status.aws.amazon.com</a></pre></center></body></html>")
 

--- a/engine/src/juliabox/srvr_jbox.py
+++ b/engine/src/juliabox/srvr_jbox.py
@@ -113,8 +113,8 @@ class JBox(LoggerMixin):
 
     @staticmethod
     def update_juliabox_status():
-        in_error = len(JBoxInstanceProps.get_stale_instances())
-        instance_status = JBoxInstanceProps.get_instance_status()
+        in_error = len(JBoxInstanceProps.get_stale_instances(Compute.get_install_id()))
+        instance_status = JBoxInstanceProps.get_instance_status(Compute.get_install_id())
 
         HTML = "<html><body><center><pre>\nJuliaBox is Up.\n\nLast updated: " + datetime.datetime.now().isoformat() + " UTC\n\nLoads: "
         for iid in instance_status:

--- a/scripts/install/create_tables_cloudsql.py
+++ b/scripts/install/create_tables_cloudsql.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "engine", "s
 import MySQLdb
 import time
 
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBPluginDB, JBoxAPISpec
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec
 from juliabox.jbox_util import JBoxCfg
 
 # import any plugins that contribute tables
@@ -37,6 +37,7 @@ def table_create(table_name, columns=None, types=None, keys=None, keys_types=Non
     c.execute(sql)
     conn.commit()
 
+
 def indexes_create(table_name, indexes):
     if indexes == None:
         return
@@ -46,6 +47,7 @@ def indexes_create(table_name, indexes):
         sql = "CREATE INDEX `%s` ON %s(%s)" % (name, table_name, cols)
         c.execute(sql)
         conn.commit()
+
 
 def get_connection():
     # Copy from /jboxengine/conf/jbox.user
@@ -62,7 +64,7 @@ def get_connection():
 conn = get_connection()
 c = conn.cursor()
 
-tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxAPISpec]
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec]
 for plugin in JBPluginDB.jbox_get_plugins(JBPluginDB.JBP_TABLE_DYNAMODB):
     tables.append(plugin)
 

--- a/scripts/install/create_tables_dynamodb.py
+++ b/scripts/install/create_tables_dynamodb.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "engine", "src"))
 
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBPluginDB, JBoxAPISpec
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec
 
 # import any plugins that contribute tables
 import juliabox.plugins.course_homework
@@ -22,7 +22,7 @@ def table_exists(name):
     except:
         return False
 
-tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxAPISpec]
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec]
 for plugin in JBPluginDB.jbox_get_plugins(JBPluginDB.JBP_TABLE_DYNAMODB):
     tables.append(plugin)
 

--- a/scripts/install/create_tables_sqlite.py
+++ b/scripts/install/create_tables_sqlite.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "engine", "s
 
 import sqlite3
 
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBPluginDB, JBoxAPISpec
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec
 
 # import any plugins that contribute tables
 import juliabox.plugins.course_homework
@@ -34,7 +34,7 @@ print("connecting to %s" % (sys.argv[1],))
 conn = sqlite3.connect(sys.argv[1])
 c = conn.cursor()
 
-tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxAPISpec]
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec]
 for plugin in JBPluginDB.jbox_get_plugins(JBPluginDB.JBP_TABLE_RDBMS):
     tables.append(plugin)
 

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -25,7 +25,7 @@ TESTCLSTR = 'testcluster'
 class TestDBTables(LoggerMixin):
     @staticmethod
     def test():
-        sprops = JBoxSessionProps(unique_sessname('tanmaykm@gmail.com'))
+        sprops = JBoxSessionProps(TESTCLSTR, unique_sessname('tanmaykm@gmail.com'))
         TestDBTables.log_debug("JBoxSessionProps. user_id: %s, snapshot_id: %s, message: %s",
                                sprops.get_user_id(),
                                sprops.get_snapshot_id(),


### PR DESCRIPTION
Helps scaling JuliaBox up to a large number of machines.
Necessary when configured for dedicated machines instead of shared.

- Individual instances publish session data to `jbox_session` table. Instead of RPC calls to all instances,
    - query `jbox_session` to get logged in instance of a user 
    - scan `jbox_session` to list active sessions
- Maintain instance statistics in a new table (`jbox_instance`) instead of querying individual instances.
- Change compute_ec2 plugin to use `jbox_instance` table to reduce api calls and avoid iterating through / querying all instances.

Tested with a large static cluster. For an auto scaling cluster, scale down and instance allocation logic will need small changes on similar lines.