### PR TITLE
Ignore 400 errors when uploading logs

### DIFF
--- a/scripts/run/gce/logger_daemon.py
+++ b/scripts/run/gce/logger_daemon.py
@@ -15,6 +15,7 @@ import httplib
 from socket import gethostname
 from oauth2client.client import GoogleCredentials
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 import errno
 import json
 import requests
@@ -59,7 +60,11 @@ def cloud_log(data_list):
     body = {
         'entries': data_list,
     }
-    ent.write(body=body).execute()
+    try:
+        ent.write(body=body).execute()
+    except HttpError, e:
+        if e.resp.status != 400:
+            raise
 
 def get_log_data(line, source, sev=None):
     if not sev:


### PR DESCRIPTION
If an error occurs and the logger restarts, the old file handles are lost.  This causes all the logs starting from time=0 to be uploaded at once.  The size limit for uploading logs is 10MB, so this error will happen repeatedly.

Prevent this by ignoring 400 status associated with this error.