### PR TITLE
git clone warns and does not delete existing files

### DIFF
--- a/container/interactive/IJulia/tornado/src/fmanage.py
+++ b/container/interactive/IJulia/tornado/src/fmanage.py
@@ -235,11 +235,14 @@ class SyncHandler(tornado.web.RequestHandler):
             if len(loc) == 0:
                 loc = git_url[(git_url.rindex('/') + 1):git_url.rindex('.')]
             loc = os.path.join(os.path.expanduser(SyncHandler.LOC), loc)
-            gs = GitSync.clone(git_url, loc, True)
-            gs.checkout(git_branch, from_remote=True)
-
-            if git_url.startswith('https://'):
-                retcode = 1
+            empty = (not os.path.exists(loc)) or (os.path.isdir(loc) and not os.listdir(loc))
+            if empty:
+                gs = GitSync.clone(git_url, loc, True)
+                gs.checkout(git_branch, from_remote=True)
+                if git_url.startswith('https://'):
+                    retcode = 1
+            else:
+                retcode = -2
         return retcode
 
     @staticmethod

--- a/webserver/www/assets/js/juliabox.js
+++ b/webserver/www/assets/js/juliabox.js
@@ -293,6 +293,9 @@ var JuliaBox = (function($, _, undefined){
 				else if(res.code == 1) {
 					self.inpage_alert('warning', 'Repository added successfully. Pushing changes to remote repository not supported with HTTP URLs.');
 				}
+				else if(res.code == -2) {
+					self.inpage_alert('danger', 'Error adding repository. Destination path already exists and is not empty.');
+				}
 				else {
 					self.inpage_alert('danger', 'Error adding repository');
 				}


### PR DESCRIPTION
Git clone is allowed only when the destination path does not exist or is an empty folder.
Fails with an indicative error message otherwise.

fixes #375