### PR TITLE
add GitHub OAuth2 authentication plugin

### DIFF
--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -64,7 +64,13 @@
         "key": "",
         "secret": ""
     },
-    
+
+    # if using GitHub auth, the API key and secret to use
+    "github_oauth": {
+        "key": "",
+        "secret": ""
+    },
+
     "cloud_host": {
     	"install_id": "JuliaBox",
     	"region": "us-east-1",

--- a/engine/src/juliabox/handlers/handler_base.py
+++ b/engine/src/juliabox/handlers/handler_base.py
@@ -496,6 +496,7 @@ class JBPluginHandler(JBoxHandler):
     JBP_HANDLER_AUTH = 'handler.auth'
     JBP_HANDLER_AUTH_ZERO = 'handler.auth.zero'
     JBP_HANDLER_AUTH_GOOGLE = 'handler.auth.google'
+    JBP_HANDLER_AUTH_GITHUB = 'handler.auth.github'
     JBP_JS_TOP = 'handler.js.top'
 
     JBP_HANDLER_POST_AUTH = 'handler.post_auth'

--- a/engine/src/juliabox/plugins/auth_github/__init__.py
+++ b/engine/src/juliabox/plugins/auth_github/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'tan'
+from github_auth import GitHubAuthHandler, GitHubAuthUIHandler

--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -1,0 +1,123 @@
+import json
+import os
+import urllib
+import functools
+
+import tornado
+import tornado.web
+import tornado.gen
+import tornado.httpclient
+import tornado.escape
+import tornado.httputil
+from tornado.auth import OAuth2Mixin, _auth_return_future, AuthError
+
+from juliabox.jbox_util import JBoxCfg
+from juliabox.handlers import JBPluginHandler, JBPluginUI
+
+__author__ = 'tan'
+
+
+class GitHubAuthUIHandler(JBPluginUI):
+    provides = [JBPluginUI.JBP_UI_AUTH_BTN]
+    TEMPLATE_PATH = os.path.dirname(__file__)
+
+    @staticmethod
+    def get_template(plugin_type):
+        if plugin_type == JBPluginUI.JBP_UI_AUTH_BTN:
+            return os.path.join(GitHubAuthUIHandler.TEMPLATE_PATH, "github_login_btn.tpl")
+
+
+class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
+    provides = [JBPluginHandler.JBP_HANDLER,
+                JBPluginHandler.JBP_HANDLER_AUTH,
+                JBPluginHandler.JBP_HANDLER_AUTH_GITHUB]
+
+    _OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+    _OAUTH_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+    _OAUTH_NO_CALLBACKS = False
+    _OAUTH_SETTINGS_KEY = 'github_oauth'
+
+    SCOPES = ['user:email']
+    EXTRA_PARAMS = {'allow_signup': 'true'}
+
+    @staticmethod
+    def register(app):
+        app.add_handlers(".*$", [(r"/jboxauth/github/", GitHubAuthHandler)])
+        app.settings["github_oauth"] = JBoxCfg.get('github_oauth')
+
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
+    def get(self):
+        # self_redirect_uri should be similar to  'http://<host>/jboxauth/github/'
+        self_redirect_uri = self.request.full_url()
+        idx = self_redirect_uri.index("jboxauth/github/")
+        self_redirect_uri = self_redirect_uri[0:(idx + len("jboxauth/github/"))]
+
+        code = self.get_argument('code', False)
+        if code is not False:
+            user = yield self.get_authenticated_user(redirect_uri=self_redirect_uri, code=code)
+            user_info = yield self.get_user_info(user)
+            user_id = user_info['email']
+            GitHubAuthHandler.log_debug("logging in user_id=%r", user_id)
+            self.post_auth_launch_container(user_id)
+            return
+        else:
+            yield self.authorize_redirect(redirect_uri=self_redirect_uri,
+                                          client_id=self.settings[self._OAUTH_SETTINGS_KEY]['key'],
+                                          scope=self.SCOPES,
+                                          response_type='code',
+                                          extra_params=self.EXTRA_PARAMS)
+
+    @_auth_return_future
+    def get_user_info(self, user, callback):
+        http = self.get_auth_http_client()
+        auth_string = "%s %s" % (user['token_type'], user['access_token'])
+        headers = {
+            "Authorization": auth_string,
+            "User-Agent": "JuliaBox Tornado Python client"
+        }
+        http.fetch('https://api.github.com/user',
+                   functools.partial(self._on_user_info, callback),
+                   headers=headers)
+
+    @_auth_return_future
+    def get_authenticated_user(self, redirect_uri, code, callback):
+        """Handles GitHub login, returning a user object.
+        """
+        http = self.get_auth_http_client()
+        body = urllib.urlencode({
+            "redirect_uri": redirect_uri,
+            "code": code,
+            "client_id": self.settings[self._OAUTH_SETTINGS_KEY]['key'],
+            "client_secret": self.settings[self._OAUTH_SETTINGS_KEY]['secret']
+        })
+
+        http.fetch(self._OAUTH_ACCESS_TOKEN_URL,
+                   functools.partial(self._on_access_token, callback),
+                   method="POST", headers={'Content-Type': 'application/x-www-form-urlencoded'}, body=body)
+
+    def _on_user_info(self, future, response):
+        if response.error:
+            future.set_exception(AuthError('GitHub auth error: %s [%s]' % (str(response), response.body)))
+            return
+        user_info = json.loads(response.body)
+        future.set_result(user_info)
+
+    def _on_access_token(self, future, response):
+        """Callback function for the exchange to the access token."""
+        if response.error:
+            future.set_exception(AuthError('GitHub auth error: %s' % str(response)))
+            return
+        args = dict()
+        tornado.httputil.parse_body_arguments(response.headers.get("Content-Type"), response.body, args, None)
+        args['access_token'] = args['access_token'][0]
+        args['token_type'] = args['token_type'][0]
+        future.set_result(args)
+
+    def get_auth_http_client(self):
+        """Returns the `.AsyncHTTPClient` instance to be used for auth requests.
+
+        May be overridden by subclasses to use an HTTP client other than
+        the default.
+        """
+        return tornado.httpclient.AsyncHTTPClient()

--- a/engine/src/juliabox/plugins/auth_github/github_login_btn.tpl
+++ b/engine/src/juliabox/plugins/auth_github/github_login_btn.tpl
@@ -1,0 +1,2 @@
+<a class="btn btn-primary btn-block gauth-btn" title="Sign in via GitHub" href="/jboxauth/github/">Sign in via GitHub</a>
+<br/>


### PR DESCRIPTION
fixes #247

- register application with GitHub (as described in https://developer.github.com/v3/oauth/)
- use `juliabox.plugins.auth_github` as plugin
- specify github client id and secret in `github_oauth` section, e.g.: `"github_oauth": { "key": "<client id>", "secret": "<secret>" }`