### PR TITLE
Change gtok type to TEXT in cloudsql

### DIFF
--- a/engine/src/juliabox/db/user_v2.py
+++ b/engine/src/juliabox/db/user_v2.py
@@ -72,7 +72,7 @@ class JBoxUserV2(JBoxDB):
     TYPES = [JBoxDB.INT, JBoxDB.INT, JBoxDB.INT, JBoxDB.INT,
              JBoxDB.INT, JBoxDB.VCHAR, JBoxDB.INT,
              JBoxDB.INT, JBoxDB.VCHAR,
-             JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.INT, JBoxDB.INT]
+             JBoxDB.TEXT, JBoxDB.VCHAR, JBoxDB.INT, JBoxDB.INT]
 
     STATUS_ACTIVE = 0
     STATUS_INACTIVE = 1


### PR DESCRIPTION
`JBoxDB.VCHAR` is too short to hold the google token.  Hence changing it to `JBoxDB.TEXT`.