### PR TITLE
add user profile table

### DIFF
--- a/engine/src/juliabox/db/__init__.py
+++ b/engine/src/juliabox/db/__init__.py
@@ -1,12 +1,14 @@
-__author__ = 'tan'
 from db_base import JBoxDB, JBPluginDB, JBoxDBItemNotFound
 from user_v2 import JBoxUserV2
+from user_profile import JBoxUserProfile
 from container import JBoxSessionProps
 from instance import JBoxInstanceProps
 from dynconfig import JBoxDynConfig
 from api_spec import JBoxAPISpec
 from juliabox.cloud import Compute
 from juliabox.jbox_util import JBoxCfg
+
+__author__ = 'tan'
 
 
 def configure():

--- a/engine/src/juliabox/db/api_spec.py
+++ b/engine/src/juliabox/db/api_spec.py
@@ -15,7 +15,8 @@ class JBoxAPISpec(JBoxDB):
         HashKey('api_name', data_type=STRING)
     ]
 
-    INDEXES = [
+    INDEXES = None
+    GLOBAL_INDEXES = [
         GlobalKeysOnlyIndex('publisher-api_name-index', parts=[
             HashKey('publisher', data_type=STRING),
             RangeKey('api_name', data_type=STRING)

--- a/engine/src/juliabox/db/container.py
+++ b/engine/src/juliabox/db/container.py
@@ -16,6 +16,7 @@ class JBoxSessionProps(JBoxDB):
     ]
 
     INDEXES = None
+    GLOBAL_INDEXES = None
 
     TABLE = None
 

--- a/engine/src/juliabox/db/dynconfig.py
+++ b/engine/src/juliabox/db/dynconfig.py
@@ -18,6 +18,7 @@ class JBoxDynConfig(JBoxDB):
     ]
 
     INDEXES = None
+    GLOBAL_INDEXES = None
 
     TABLE = None
 

--- a/engine/src/juliabox/db/instance.py
+++ b/engine/src/juliabox/db/instance.py
@@ -16,6 +16,7 @@ class JBoxInstanceProps(JBoxDB):
     ]
 
     INDEXES = None
+    GLOBAL_INDEXES = None
 
     TABLE = None
 

--- a/engine/src/juliabox/db/user_profile.py
+++ b/engine/src/juliabox/db/user_profile.py
@@ -15,7 +15,8 @@ class JBoxUserProfile(JBoxDB):
         HashKey('user_id', data_type=STRING)
     ]
 
-    INDEXES = [
+    INDEXES = None
+    GLOBAL_INDEXES = [
         GlobalKeysOnlyIndex('create_month-create_time-index', parts=[
             HashKey('create_month', data_type=NUMBER),
             RangeKey('create_time', data_type=NUMBER)

--- a/engine/src/juliabox/db/user_profile.py
+++ b/engine/src/juliabox/db/user_profile.py
@@ -1,0 +1,140 @@
+import datetime
+import pytz
+import json
+
+from boto.dynamodb2.fields import HashKey, RangeKey, GlobalKeysOnlyIndex
+from boto.dynamodb2.types import NUMBER, STRING
+
+from juliabox.db import JBoxDB, JBoxDBItemNotFound
+
+
+class JBoxUserProfile(JBoxDB):
+    NAME = 'jbox_user_profiles'
+
+    SCHEMA = [
+        HashKey('user_id', data_type=STRING)
+    ]
+
+    INDEXES = [
+        GlobalKeysOnlyIndex('create_month-create_time-index', parts=[
+            HashKey('create_month', data_type=NUMBER),
+            RangeKey('create_time', data_type=NUMBER)
+        ]),
+        GlobalKeysOnlyIndex('update_month-update_time-index', parts=[
+            HashKey('update_month', data_type=NUMBER),
+            RangeKey('update_time', data_type=NUMBER)
+        ])
+    ]
+
+    TABLE = None
+
+    ATTR_FIRST_NAME = 'first_name'
+    ATTR_LAST_NAME = 'last_name'
+    ATTR_COUNTRY = 'country'
+    ATTR_CITY = 'city'
+    ATTR_LOCATION = 'location'          # a fuzzy location string, indicative of country and city
+    ATTR_IP = 'ip'                      # ip from which last accessed
+    ATTR_INDUSTRY = 'industry'
+    ATTR_ORGANIZATION = 'org'           # workplace
+    ATTR_ORG_TITLE = 'org_title'        # job title
+
+    KEYS = ['user_id']
+    ATTRIBUTES = ['create_month', 'create_time', 'update_month', 'update_time',
+                  ATTR_FIRST_NAME, ATTR_LAST_NAME,
+                  ATTR_COUNTRY, ATTR_CITY, ATTR_LOCATION, ATTR_IP,
+                  ATTR_INDUSTRY, ATTR_ORGANIZATION, ATTR_ORG_TITLE,
+                  'sources'  # a JSON field that indicates where each profile attribute was filled from
+                  ]
+    SQL_INDEXES = [
+        {'name': 'create_month-create_time-index',
+         'cols': ['create_month', 'create_time']},
+        {'name': 'update_month-update_time-index',
+         'cols': ['update_month', 'update_time']},
+        {'name': 'activation_code-activation_status-index',
+         'cols': ['activation_code', 'activation_status']},
+    ]
+    KEYS_TYPES = [JBoxDB.VCHAR]
+    TYPES = [JBoxDB.INT, JBoxDB.INT, JBoxDB.INT, JBoxDB.INT,
+             JBoxDB.VCHAR, JBoxDB.VCHAR,
+             JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR,
+             JBoxDB.VCHAR, JBoxDB.VCHAR, JBoxDB.VCHAR,
+             JBoxDB.VCHAR]
+
+    SRC_USER = 1            # filled in by the user
+    SRC_DERIVED = 2         # derived from other fields
+
+    def __init__(self, user_id, create=False):
+        try:
+            self.item = self.fetch(user_id=user_id)
+            self.is_new = False
+        except JBoxDBItemNotFound:
+            if create:
+                data = {
+                    'user_id': user_id
+                }
+                JBoxUserProfile._set_time(data, "create")
+                self.create(data)
+                self.item = self.fetch(user_id=user_id)
+                self.is_new = True
+            else:
+                raise
+
+    def get_user_id(self):
+        return self.get_attrib('user_id')
+
+    def get_attrib_source(self, attrib_name):
+        sources_str = self.get_attrib('sources', '{}')
+        if len(sources_str) == 0:
+            return None
+        sources = json.loads(sources_str)
+        return sources[attrib_name] if attrib_name in sources else None
+
+    def set_attrib_source(self, attrib_name, source):
+        sources_str = self.get_attrib('sources', '{}')
+        if len(sources_str) == 0:
+            sources_str = '{}'
+        sources = json.loads(sources_str)
+        sources[attrib_name] = source
+        self.set_attrib('sources', json.dumps(sources))
+
+    def is_set_by_user(self, attrib_name):
+        return self.get_attrib_source(attrib_name) == JBoxUserProfile.SRC_USER
+
+    def set_profile(self, attrib_name, value, source):
+        # do not overwrite attributes set by the user
+        if source != JBoxUserProfile.SRC_USER and self.is_set_by_user(attrib_name):
+            return False
+        self.set_attrib(attrib_name, value)
+        self.set_attrib_source(attrib_name, source)
+        return True
+
+    def can_set(self, attrib_name, value):
+        if value is None or len(value) == 0:
+            return False
+        return value != self.get_attrib(attrib_name)
+
+    def get_profile(self, attrib_name, default=''):
+        return self.get_attrib(attrib_name, default)
+
+    def set_time(self, prefix, dt=None):
+        JBoxUserProfile._set_time(self.item, prefix, dt)
+
+    @staticmethod
+    def _set_time(item, prefix, dt=None):
+        if dt is None:
+            dt = datetime.datetime.now(pytz.utc)
+
+        if prefix not in ["create", "update"]:
+            raise (Exception("invalid prefix for setting time"))
+
+        item[prefix + "_month"] = JBoxUserProfile.datetime_to_yyyymm(dt)
+        item[prefix + "_time"] = JBoxUserProfile.datetime_to_epoch_secs(dt)
+
+    def get_time(self, prefix):
+        if prefix not in ["create", "update"]:
+            raise (Exception("invalid prefix for setting time"))
+        return JBoxUserProfile.epoch_secs_to_datetime(self.item[prefix + "_time"])
+
+    def save(self, set_time=True):
+        self.set_time("update")
+        super(JBoxUserProfile, self).save()

--- a/engine/src/juliabox/db/user_v2.py
+++ b/engine/src/juliabox/db/user_v2.py
@@ -38,7 +38,8 @@ class JBoxUserV2(JBoxDB):
         HashKey('user_id', data_type=STRING)
     ]
 
-    INDEXES = [
+    INDEXES = None
+    GLOBAL_INDEXES = [
         GlobalKeysOnlyIndex('create_month-create_time-index', parts=[
             HashKey('create_month', data_type=NUMBER),
             RangeKey('create_time', data_type=NUMBER)

--- a/engine/src/juliabox/handlers/handler_base.py
+++ b/engine/src/juliabox/handlers/handler_base.py
@@ -442,6 +442,10 @@ class JBoxHandler(JBoxCookies):
         self.redirect('/')
         return
 
+    def get_client_ip(self):
+        x_real_ip = self.request.headers.get("X-Real-IP")
+        return x_real_ip or self.request.remote_ip
+
 
 class JBPluginUI(LoggerMixin):
     """ Provide UI widgets/sections in a JuliaBox session.

--- a/engine/src/juliabox/plugins/site_redirect/impl_site_redirect.py
+++ b/engine/src/juliabox/plugins/site_redirect/impl_site_redirect.py
@@ -29,6 +29,7 @@ class SiteRedirectHandler(JBPluginHandler):
 
             SiteRedirectHandler.log_info("Configured to redirect %s users to %s",
                                          rtype, SiteRedirectHandler.REDIRECT_URL)
+            SiteRedirectHandler.CONFIGURED = True
 
     @staticmethod
     def process_user_id(handler, user_id):

--- a/scripts/install/create_tables_cloudsql.py
+++ b/scripts/install/create_tables_cloudsql.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "engine", "s
 import MySQLdb
 import time
 
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec, JBoxUserProfile
 from juliabox.jbox_util import JBoxCfg
 
 # import any plugins that contribute tables
@@ -64,7 +64,7 @@ def get_connection():
 conn = get_connection()
 c = conn.cursor()
 
-tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec]
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec, JBoxUserProfile]
 for plugin in JBPluginDB.jbox_get_plugins(JBPluginDB.JBP_TABLE_DYNAMODB):
     tables.append(plugin)
 

--- a/scripts/install/create_tables_dynamodb.py
+++ b/scripts/install/create_tables_dynamodb.py
@@ -31,7 +31,7 @@ for cls in tables:
     if table_exists(cls.NAME):
         print("\texists already!")
     else:
-        Table.create(cls.NAME, schema=cls.SCHEMA, indexes=cls.INDEXES, throughput={
+        Table.create(cls.NAME, schema=cls.SCHEMA, indexes=cls.INDEXES, global_indexes=cls.GLOBAL_INDEXES, throughput={
             'read': 1,
             'write': 1
         })

--- a/scripts/install/create_tables_dynamodb.py
+++ b/scripts/install/create_tables_dynamodb.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "engine", "src"))
 
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec, JBoxUserProfile
 
 # import any plugins that contribute tables
 import juliabox.plugins.course_homework
@@ -22,7 +22,7 @@ def table_exists(name):
     except:
         return False
 
-tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec]
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec, JBoxUserProfile]
 for plugin in JBPluginDB.jbox_get_plugins(JBPluginDB.JBP_TABLE_DYNAMODB):
     tables.append(plugin)
 

--- a/scripts/install/create_tables_sqlite.py
+++ b/scripts/install/create_tables_sqlite.py
@@ -6,7 +6,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "engine", "s
 
 import sqlite3
 
-from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB, JBoxAPISpec
+from juliabox.db import JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBPluginDB,\
+    JBoxAPISpec, JBoxUserProfile
 
 # import any plugins that contribute tables
 import juliabox.plugins.course_homework
@@ -34,7 +35,7 @@ print("connecting to %s" % (sys.argv[1],))
 conn = sqlite3.connect(sys.argv[1])
 c = conn.cursor()
 
-tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec]
+tables = [JBoxUserV2, JBoxDynConfig, JBoxSessionProps, JBoxInstanceProps, JBoxAPISpec, JBoxUserProfile]
 for plugin in JBPluginDB.jbox_get_plugins(JBPluginDB.JBP_TABLE_RDBMS):
     tables.append(plugin)
 


### PR DESCRIPTION
Add user_profiles table, auto fill by auth modules.

The profile table stores a few attributes to use while communicating with users. Authentication modules fill attributes if they are available to them as part of the login response. A record is maintained to indicate the source of each attribute that was populated automatically.

If users are allowed to explicitly set their profile in the future, authentication modules will not overwrite the values set by users.

This also includes a minor change to the AWS index specification to handle a boto API change.