### PR TITLE
Show error page if email is not available when using GitHub Auth

### DIFF
--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -65,11 +65,11 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
         if code is not False:
             user = yield self.get_authenticated_user(redirect_uri=self_redirect_uri, code=code)
             user_info = yield self.get_user_info(user)
-            user_id = user_info['email']
-            if not user_id:
+            if not user_info.get('email'):
                 self.rendertpl("index.tpl", cfg=JBoxCfg.nv, state=self.state(
                     error="Please make your email public in your GitHub profile if you wish to sign in with GitHub", success="")
                 return
+            user_id = user_info['email']
             self.update_user_profile(user_info)
             GitHubAuthHandler.log_debug("logging in user_id=%r", user_id)
             self.post_auth_launch_container(user_id)

--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -46,6 +46,13 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
         app.add_handlers(".*$", [(r"/jboxauth/github/", GitHubAuthHandler)])
         app.settings["github_oauth"] = JBoxCfg.get('github_oauth')
 
+    @staticmethod
+    def state(**kwargs):
+        s = dict(error="", success="", info="",
+                 pending_activation=False, user_id="")
+        s.update(**kwargs)
+        return s
+
     @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
@@ -58,8 +65,12 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
         if code is not False:
             user = yield self.get_authenticated_user(redirect_uri=self_redirect_uri, code=code)
             user_info = yield self.get_user_info(user)
-            self.update_user_profile(user_info)
             user_id = user_info['email']
+            if not user_id:
+                self.rendertpl("index.tpl", cfg=JBoxCfg.nv, state=self.state(
+                    error="Please make your email public in your GitHub profile if you wish to use GitHub Authentication", success="")
+                return
+            self.update_user_profile(user_info)
             GitHubAuthHandler.log_debug("logging in user_id=%r", user_id)
             self.post_auth_launch_container(user_id)
             return

--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -68,7 +68,7 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
             user_id = user_info['email']
             if not user_id:
                 self.rendertpl("index.tpl", cfg=JBoxCfg.nv, state=self.state(
-                    error="Please make your email public in your GitHub profile if you wish to use GitHub Authentication", success="")
+                    error="Please make your email public in your GitHub profile if you wish to sign in with GitHub", success="")
                 return
             self.update_user_profile(user_info)
             GitHubAuthHandler.log_debug("logging in user_id=%r", user_id)


### PR DESCRIPTION
If user has not made email public in GitHub profile then login is not possible.  Show an error asking user to make email public.