### PR TITLE
Set charset to utf-8 in cloudsql

### DIFF
--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -67,7 +67,7 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
             user_info = yield self.get_user_info(user)
             if not user_info.get('email'):
                 self.rendertpl("index.tpl", cfg=JBoxCfg.nv, state=self.state(
-                    error="Please make your email public in your GitHub profile if you wish to sign in with GitHub", success="")
+                    error="Please make your email public in your GitHub profile if you wish to sign in with GitHub", success=""))
                 return
             user_id = user_info['email']
             self.update_user_profile(user_info)

--- a/engine/src/juliabox/plugins/db_cloudsql/impl_cloudsql.py
+++ b/engine/src/juliabox/plugins/db_cloudsql/impl_cloudsql.py
@@ -206,6 +206,11 @@ class JBoxCloudSQL(JBPluginDB):
                 user=JBoxCloudSQL.USER, passwd=JBoxCloudSQL.PASSWD,
                 unix_socket=JBoxCloudSQL.UNIX_SOCKET, db=JBoxCloudSQL.DB)
             c.autocommit(True)
+            c.set_character_set('utf8')
+            cur = c.cursor()
+            cur.execute('SET NAMES utf8;')
+            cur.execute('SET CHARACTER SET utf8;')
+            cur.execute('SET character_set_connection=utf8;')
         return c
 
     @staticmethod


### PR DESCRIPTION
The python package `MySQLdb` uses `latin-1` charset by default.  Changing charset to `utf-8`.