### PR TITLE
Prevent login failures due to profile update errors

### DIFF
--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -2,7 +2,7 @@ import json
 import os
 import urllib
 import functools
-
+import traceback
 import tornado
 import tornado.web
 import tornado.gen
@@ -70,7 +70,11 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
                     error="Please make your email public in your GitHub profile if you wish to sign in with GitHub", success=""))
                 return
             user_id = user_info['email']
-            self.update_user_profile(user_info)
+            try:
+                self.update_user_profile(user_info)
+            except:
+                self.log_error("exception while capturing user profile")
+                traceback.print_exc()
             GitHubAuthHandler.log_debug("logging in user_id=%r", user_id)
             self.post_auth_launch_container(user_id)
             return

--- a/engine/src/juliabox/plugins/auth_google/google_auth.py
+++ b/engine/src/juliabox/plugins/auth_google/google_auth.py
@@ -3,6 +3,7 @@ import json
 import os
 import base64
 import httplib2
+import traceback
 
 import tornado
 import tornado.web
@@ -88,7 +89,11 @@ class GoogleAuthHandler(JBPluginHandler, GoogleOAuth2Mixin):
             response = yield http.fetch('https://www.googleapis.com/userinfo/v2/me',
                                         headers={"Authorization": auth_string})
             user_info = json.loads(response.body)
-            self.update_user_profile(user_info)
+            try:
+                self.update_user_profile(user_info)
+            except:
+                self.log_error("exception while capturing user profile")
+                traceback.print_exc()
             user_id = user_info['email']
 
             if state == 'store_creds':

--- a/engine/src/juliabox/plugins/auth_linkedin/linkedin_auth.py
+++ b/engine/src/juliabox/plugins/auth_linkedin/linkedin_auth.py
@@ -2,7 +2,7 @@ import json
 import os
 import urllib
 import functools
-
+import traceback
 import tornado
 import tornado.web
 import tornado.gen
@@ -69,7 +69,11 @@ class LinkedInAuthHandler(JBPluginHandler, OAuth2Mixin):
         if code is not False:
             user = yield self.get_authenticated_user(redirect_uri=self_redirect_uri, code=code)
             user_info = yield self.get_user_info(user)
-            self.update_user_profile(user_info)
+            try:
+                self.update_user_profile(user_info)
+            except:
+                self.log_error("exception while capturing user profile")
+                traceback.print_exc()
             user_id = user_info['emailAddress']
             LinkedInAuthHandler.log_debug("logging in user_id=%r", user_id)
             self.post_auth_launch_container(user_id)


### PR DESCRIPTION
Catch errors that occur when updating profile.  Print the traceback.